### PR TITLE
Code Consistency with downloadRunner: cvMetadata gathered from server, argparse implemented & other simple tweaks

### DIFF
--- a/CropRunner.py
+++ b/CropRunner.py
@@ -207,12 +207,12 @@ def bulk_extract_crops(label_infos, path_to_gsv_scrapes, destination_dir, mark_l
             counter += 1
             continue
 
-        pano_id = row[0]
+        pano_id = row['gsv_panorama_id']
         print(pano_id)
-        pano_x = float(row[1])
-        pano_y = float(row[2])
-        label_type = int(row[3])
-        label_id = int(row[7])
+        pano_x = float(row['pano_x'])
+        pano_y = float(row['pano_y'])
+        label_type = int(row['label_type_id'])
+        label_id = int(row['label_id'])
 
         pano_img_path = os.path.join(path_to_gsv_scrapes, pano_id[:2], pano_id + ".jpg")
 

--- a/CropRunner.py
+++ b/CropRunner.py
@@ -15,7 +15,6 @@ path to the folder containing these files.
 """
 
 import sys
-import csv
 import logging
 import os
 from PIL import Image, ImageDraw
@@ -77,7 +76,7 @@ def request_session():
 # This function may be deprecated, since json is the only and current file format of metadata
 def fetch_label_ids_csv(metadata_csv_path):
     """
-    Reads metadata from a csv. Useful for old csv formats of cvMetadata such as cv-metadata-seatle.csv
+    Reads metadata from a csv. Useful for old csv formats of cvMetadata such as cv-metadata-seattle.csv
     :param metadata_csv_path: The path to the metadata csv file and the file's name eg. sample/metadata-seattle.csv
     :return: A list of dicts containing the follow metadata: gsv_panorama_id, pano_x, pano_y, zoom, label_type_id,
              camera_heading, heading, pitch, label_id, width, height, tile_width, tile_height, image_date, imagery_type,
@@ -203,15 +202,10 @@ def make_single_crop(path_to_image, pano_x, pano_y, output_filename, draw_mark=F
 
 
 def bulk_extract_crops(label_infos, path_to_gsv_scrapes, destination_dir, mark_label=False):
-    counter = 0
     no_metadata_fail = 0
     no_pano_fail = 0
 
     for row in label_infos:
-        if counter == 0:
-            counter += 1
-            continue
-
         pano_id = row['gsv_panorama_id']
         print(pano_id)
         pano_x = float(row['pano_x'])
@@ -224,7 +218,6 @@ def bulk_extract_crops(label_infos, path_to_gsv_scrapes, destination_dir, mark_l
         print(pano_img_path)
         # Extract the crop
         if os.path.exists(pano_img_path):
-            counter += 1
             destination_folder = os.path.join(destination_dir, str(label_type))
             if not os.path.isdir(destination_folder):
                 os.makedirs(destination_folder)

--- a/DownloadRunner.py
+++ b/DownloadRunner.py
@@ -96,7 +96,7 @@ def request_session():
     :return: session
     """
     session = requests.Session()
-    retry = Retry(total=10, connect=5, status_forcelist=[429, 500, 502, 503, 504], backoff_factor=1)
+    retry = Retry(total=5, connect=5, status_forcelist=[429, 500, 502, 503, 504], backoff_factor=1)
     adapter = HTTPAdapter(max_retries=retry)
     session.mount('http://', adapter)
     session.mount('https://', adapter)

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ There are two main scripts of note: [DownloadRunner.py](DownloadRunner.py) and [
 1. [Install  Docker Desktop](https://www.docker.com/get-started).
 1. Run `git clone https://github.com/ProjectSidewalk/sidewalk-panorama-tools.git` in the directory where you want to put the code.
 1. Create the Docker image
-  ```
-  docker build --no-cache --pull -t projectsidewalk/scraper:v5 <path-to-pano-tools-repo>
-  ```
+    ```
+    docker build --no-cache --pull -t projectsidewalk/scraper:v5 <path-to-pano-tools-repo>
+    ```
 1. You can then run the downloader using the following command:
-  ```
-  docker run --cap-add SYS_ADMIN --device=/dev/fuse --security-opt apparmor:unconfined projectsidewalk/scraper:v5 <project-sidewalk-url>
-  ```
-  Where the `<project-sidewalk-url>` looks like `sidewalk-columbus.cs.washington.edu` if you want data from Columbus. If you visit that URL, you will see a dropdown menu with a list of publicly deployed cities that you can pull data from.
+    ```
+    docker run --cap-add SYS_ADMIN --device=/dev/fuse --security-opt apparmor:unconfined projectsidewalk/scraper:v5 <project-sidewalk-url>
+    ```
+    Where the `<project-sidewalk-url>` looks like `sidewalk-columbus.cs.washington.edu` if you want data from Columbus. If you visit that URL, you will see a dropdown menu with a list of publicly deployed cities that you can pull data from.
 1. Right now the data is stored in a temporary directory in the Docker container. You could set up a shared volume for it, but for now you can just copy the data over using `docker cp <container-id>:/tmp/download_dest/ <local-storage-location>`, where `<local-storage-location>` is the place on your local machine where you want to save the files. You can find the `<container-id>` using `docker ps -a`.
 
 Additional settings can be configured for `DownloadRunner.py` in the configuration file `config.py`. 
@@ -30,21 +30,21 @@ Additional settings can be configured for `DownloadRunner.py` in the configurati
 
 ## Cropper
 
-`CropRunner.py` creates crops of the accessibility features from the downloaded GSV panoramas images via label data from Project Sidewalk. The script requires some data about the labels in json or CSV format.
+`CropRunner.py` creates crops of the accessibility features from the downloaded GSV panoramas images via label data from Project Sidewalk, provided by their API.
 
 Usage:
 ```python
 python CropRunner.py [-h] (-d [D] | -f [F]) [-s S] [-c C]
 ```
-- To fetch label metadata from webserver or a file, use respectively (mutually exclusive, required):
-  - ``-d <project-sidewalk-url>``
-  - ``-f <path-to-label-metadata-file>``
-- ``-s <path-to-panoramas-dir>`` (optional). Specify if using a different directory containing panoramas. Panoramas are used to crop the labels.
-- ``-c <path-of-crop-dir>`` (optional). Specify if want to set a different directory for crops to be stored.
+* To fetch label metadata from webserver or a file, use respectively (mutually exclusive, required):
+  * ``-d <project-sidewalk-url>``
+  * ``-f <path-to-label-metadata-file>``
+* ``-s <path-to-panoramas-dir>`` (optional). Specify if using a different directory containing panoramas. Panoramas are used to crop the labels.
+* ``-o <path-of-crop-dir>`` (optional). Specify if want to set a different directory for crops to be stored.
 
 As an example:
 ```python
-python CropRunner.py -d sidewalk-columbus.cs.washington.edu -s /sidewalk/columbus/panos/ -c /sidewalk/columbus/crops/
+python CropRunner.py -d sidewalk-columbus.cs.washington.edu -s /sidewalk/columbus/panos/ -o /sidewalk/columbus/crops/
 ```
 
 **Note** You will likely want to filter out labels where `disagree_count > agree_count`. These are based on human-provided validations from other Project Sidewalk users. This is not written in the code by default. There is also an option for a filter that is even more strict. This of course has the tradeoff of using less data, so this depends on the the needs of your project: more data vs more accurate data. To do this, you would query the `/v2/access/attributesWithLabels` API endpoint for the city you're looking at. Then you would only include labels where the `label_id` is also present in the attributesWithLabels API. This is a more aggressive filter that removes labels from some users that we suspect are providing low quality data based on some heuristics.

--- a/README.md
+++ b/README.md
@@ -30,10 +30,22 @@ Additional settings can be configured for `DownloadRunner.py` in the configurati
 
 ## Cropper
 
-`CropRunner.py` creates crops of the accessibility features from the downloaded GSV panoramas images via label data from Project Sidewalk. The script requires some data about the labels in CSV format. You can set the path to this file using the variable `csv_export_path`. For an example of a valid CSV file, see `samples/labeldata.csv`.
+`CropRunner.py` creates crops of the accessibility features from the downloaded GSV panoramas images via label data from Project Sidewalk. The script requires some data about the labels in json or CSV format.
 
-Update the variables at the top of the file with the path to the CSV file, the path to the folder of panoramas retrieved by `DownloadRunner`,
-and the path to the save destination. Then run `python3 CropRunner.py`.
+Usage:
+```python
+python CropRunner.py [-h] (-d [D] | -f [F]) [-s S] [-c C]
+```
+- To fetch label metadata from webserver or a file, use respectively (mutually exclusive, required):
+  - ``-d <project-sidewalk-url>``
+  - ``-f <path-to-label-metadata-file>``
+- ``-s <path-to-panoramas-dir>`` (optional). Specify if using a different directory containing panoramas. Panoramas are used to crop the labels.
+- ``-c <path-of-crop-dir>`` (optional). Specify if want to set a different directory for crops to be stored.
+
+As an example:
+```python
+python CropRunner.py -d sidewalk-columbus.cs.washington.edu -s /sidewalk/columbus/panos/ -c /sidewalk/columbus/crops/
+```
 
 **Note** You will likely want to filter out labels where `disagree_count > agree_count`. These are based on human-provided validations from other Project Sidewalk users. This is not written in the code by default. There is also an option for a filter that is even more strict. This of course has the tradeoff of using less data, so this depends on the the needs of your project: more data vs more accurate data. To do this, you would query the `/v2/access/attributesWithLabels` API endpoint for the city you're looking at. Then you would only include labels where the `label_id` is also present in the attributesWithLabels API. This is a more aggressive filter that removes labels from some users that we suspect are providing low quality data based on some heuristics.
 
@@ -95,7 +107,6 @@ Note that the numbers in the `label_type_id` column correspond to these label ty
 
 ## Suggested Improvements
 
-* `CroppRunner.py` should use data from our servers instead of a CSV.
 * `CropRunner.py` - implement multi core usage when creating crops. Currently runs on a single core, most modern machines
   have more than one core so would give a speed up for cropping 10's of thousands of images and objects.
 * Add logic to `progress_check()` function so that it can register if their is a network failure and does not log the pano id as visited and failed.


### PR DESCRIPTION
Resolves #25 

This pull request consists of some features that match `downloadRunner` code while keeping consistency:
- Now `cropRunner` fetches metadata from sidewalk webserver by calling it with HTTP request.
- Handling HTTP request errors. The reason of this feature: [#3224](https://github.com/ProjectSidewalk/SidewalkWebpage/issues/3224)
- ``fetch_label_ids_csv( )`` function modified to keep consistency with `downloadRunner`.
- Argument parser implemented.
- As current API endpoint provides json format, the script now reads json format. Also csv in case of using an [old file](https://drive.google.com/file/d/1lYNwhKGn_E6j1VBBo35afkFTIelVcpEN/view).
- Modified code to access data using column name (e.g. ``row['gsv_panorama_id']``)
- Readme file updated with new `cropRunner` usage.

**Important Notes**

Features assumed:
- The code uses single label ids. i.e. filters by `label_id` so in the hypothetical case there are two labels sharing ids referring to different panos, the script would just take one.

Features ommited in this PR:
- The script does not handle file exceptions itself.
- The code can't handle label filters yet, such as ``disagree_count > agree_count``. Therefore using API to download json and filter is needed.
- `cropRunner` is still runs with no Dockerfile.