### PR TITLE
Reserve the tail of --max-runtime for the depth phase

### DIFF
--- a/DownloadRunner.py
+++ b/DownloadRunner.py
@@ -21,6 +21,7 @@ parser.add_argument('-c', nargs='?', default=None, help='csv_path - location of 
 parser.add_argument('--all-panos', action='store_true', help='Download images for all panos that users visited, even if no labels were added on them. Does not affect depth, which always covers every pano.')
 parser.add_argument('--skip-depth', action='store_true', help='Skip downloading GSV depth maps (downloaded by default via the streetlevel library).')
 parser.add_argument('--max-runtime', type=float, default=None, metavar='MINUTES', help='Stop starting new downloads after this many minutes have elapsed.')
+parser.add_argument('--min-depth-runtime', type=float, default=60.0, metavar='MINUTES', help='Reserve the last MINUTES of --max-runtime for the depth phase, so an image backlog cannot starve depth (the image phase stops early enough to leave depth this slice; depth still ends at --max-runtime, so it also gets any slack images leave). Only meaningful with --max-runtime, ignored with --skip-depth; pass 0 to let images use the whole budget.')
 parser.add_argument('--max-depth-requests', type=int, default=None, metavar='N', help='Stop the depth phase after this many depth metadata requests.')
 # Deprecated no-op, kept for one release so existing invocations don't crash argparse.
 parser.add_argument('--attempt-depth', action='store_true', help=argparse.SUPPRESS)
@@ -32,6 +33,7 @@ pano_metadata_csv = args.c
 all_panos = args.all_panos
 skip_depth = args.skip_depth
 max_runtime_minutes = args.max_runtime
+min_depth_runtime = args.min_depth_runtime
 max_depth_requests = args.max_depth_requests
 
 if args.attempt_depth:
@@ -225,13 +227,26 @@ def download_panorama_images(storage_path, pano_infos, run_start_time=None, max_
 
 
 def run_scraper_and_log_results(image_pano_infos, depth_pano_infos, skip_depth, max_runtime_minutes=None,
-                                max_depth_requests=None):
+                                max_depth_requests=None, min_depth_runtime=0.0):
     """Run the image and depth phases and append this run's row to log.csv.
 
     @param image_pano_infos Panos eligible for image download (narrowed by --all-panos).
     @param depth_pano_infos Every supported pano; the depth phase filters this to source == 'gsv' itself.
+    @param min_depth_runtime Minutes of max_runtime_minutes reserved for the depth phase (see the flag's help).
     """
     start_time = datetime.now()
+
+    # Both phases share --max-runtime (it exists to keep the run inside its daily cron slot, per #38, and that
+    # constraint doesn't care which phase spends the clock), but the image phase must leave the reserved tail so
+    # an image backlog — a mapathon is the canonical case — can't starve the depth backfill night after night
+    # (#43). Depth still ends at the total, so slack from a light image night rolls to depth rather than being
+    # lost. No reservation when depth is skipped: the image phase keeps the whole window.
+    image_max_runtime = max_runtime_minutes
+    if max_runtime_minutes is not None and not skip_depth and min_depth_runtime > 0:
+        image_max_runtime = max(0.0, max_runtime_minutes - min_depth_runtime)
+        print("Budget: %.1f min total; image phase capped at %.1f min (%.1f reserved for depth)"
+              % (max_runtime_minutes, image_max_runtime, min_depth_runtime))
+
     with open(os.path.join(storage_location, "log.csv"), 'a') as log:
         log.write("\n%s" % (str(start_time)))
 
@@ -245,14 +260,14 @@ def run_scraper_and_log_results(image_pano_infos, depth_pano_infos, skip_depth, 
     with open(os.path.join(storage_location, "log.csv"), 'a') as log:
         log.write(",%d,%d,%d,%d,%d" % (xml_res[0], xml_res[1], xml_res[2], xml_res[3], xml_duration))
 
-    im_res = download_panorama_images(storage_location, image_pano_infos, start_time, max_runtime_minutes)
+    im_res = download_panorama_images(storage_location, image_pano_infos, start_time, image_max_runtime)
     im_end_time = datetime.now()
     im_duration = int(round((im_end_time - xml_end_time).total_seconds() / 60.0))
     with open(os.path.join(storage_location, "log.csv"), 'a') as log:
         log.write(",%d,%d,%d,%d,%d,%d" % (im_res[0], im_res[1], im_res[2], im_res[3], im_res[4], im_duration))
 
-    # Depth maps are GSV-only. This phase runs after the image phase sharing the same --max-runtime budget, so
-    # on catch-up days images (the primary artifact) win the whole window. It iterates the full pano list — not
+    # Depth maps are GSV-only. This phase runs after the image phase and ends at the shared --max-runtime, so
+    # it gets the reserved tail plus whatever slack the image phase left. It iterates the full pano list — not
     # the pano_id_log.csv-gated image loop, and not narrowed by --all-panos — which is what backfills depth for
     # panos downloaded in earlier runs and for panos nobody has labelled.
     if skip_depth:
@@ -293,4 +308,5 @@ print("Panos: %d supported, %d eligible for image download, %d GSV panos eligibl
 
 # Use pano_id list and associated info to gather panos from respective APIs
 print("Fetching Panoramas")
-run_scraper_and_log_results(image_pano_infos, pano_infos, skip_depth, max_runtime_minutes, max_depth_requests)
+run_scraper_and_log_results(image_pano_infos, pano_infos, skip_depth, max_runtime_minutes, max_depth_requests,
+                            min_depth_runtime)

--- a/DownloadRunner.py
+++ b/DownloadRunner.py
@@ -21,7 +21,7 @@ parser.add_argument('-c', nargs='?', default=None, help='csv_path - location of 
 parser.add_argument('--all-panos', action='store_true', help='Download images for all panos that users visited, even if no labels were added on them. Does not affect depth, which always covers every pano.')
 parser.add_argument('--skip-depth', action='store_true', help='Skip downloading GSV depth maps (downloaded by default via the streetlevel library).')
 parser.add_argument('--max-runtime', type=float, default=None, metavar='MINUTES', help='Stop starting new downloads after this many minutes have elapsed.')
-parser.add_argument('--min-depth-runtime', type=float, default=60.0, metavar='MINUTES', help='Reserve the last MINUTES of --max-runtime for the depth phase, so an image backlog cannot starve depth (the image phase stops early enough to leave depth this slice; depth still ends at --max-runtime, so it also gets any slack images leave). Only meaningful with --max-runtime, ignored with --skip-depth; pass 0 to let images use the whole budget.')
+parser.add_argument('--min-depth-runtime', type=float, default=0.0, metavar='MINUTES', help='Reserve the last MINUTES of --max-runtime for the depth phase when the depth ledger shows unresolved work, so an image backlog cannot starve depth. This is a reservation carved out of the image phase\'s start budget, not a hard floor on depth wall time: the image phase stops STARTING new panos once its share is spent (a pano already in flight can overrun into the reserved slice), and depth still ends at --max-runtime, so it also gets any slack images leave. If the reservation meets or exceeds --max-runtime, NO images are downloaded that run. Default 0 (no reservation); the production crontab should pass 60. Ignored without --max-runtime or with --skip-depth.')
 parser.add_argument('--max-depth-requests', type=int, default=None, metavar='N', help='Stop the depth phase after this many depth metadata requests.')
 # Deprecated no-op, kept for one release so existing invocations don't crash argparse.
 parser.add_argument('--attempt-depth', action='store_true', help=argparse.SUPPRESS)
@@ -236,16 +236,33 @@ def run_scraper_and_log_results(image_pano_infos, depth_pano_infos, skip_depth, 
     """
     start_time = datetime.now()
 
+    # Depth maps are GSV-only; the depth phase's view of the corpus is computed up front because the budget
+    # split below needs it too.
+    gsv_panos = [p for p in depth_pano_infos if p.get('source') == 'gsv']
+
     # Both phases share --max-runtime (it exists to keep the run inside its daily cron slot, per #38, and that
     # constraint doesn't care which phase spends the clock), but the image phase must leave the reserved tail so
     # an image backlog — a mapathon is the canonical case — can't starve the depth backfill night after night
-    # (#43). Depth still ends at the total, so slack from a light image night rolls to depth rather than being
+    # (#43). The reservation is only taken when the depth ledger shows unresolved work: once a city is fully
+    # backfilled the depth phase returns in milliseconds, and reserving for it would burn image throughput for
+    # nothing. Depth still ends at the total, so slack from a light image night rolls to depth rather than being
     # lost. No reservation when depth is skipped: the image phase keeps the whole window.
     image_max_runtime = max_runtime_minutes
     if max_runtime_minutes is not None and not skip_depth and min_depth_runtime > 0:
-        image_max_runtime = max(0.0, max_runtime_minutes - min_depth_runtime)
-        print("Budget: %.1f min total; image phase capped at %.1f min (%.1f reserved for depth)"
-              % (max_runtime_minutes, image_max_runtime, min_depth_runtime))
+        depth_backlog = gsv.count_unresolved_depth(storage_location, gsv_panos)
+        if depth_backlog:
+            image_max_runtime = max(0.0, max_runtime_minutes - min_depth_runtime)
+            print("Budget: %.1f min total; image phase capped at %.1f min (%.1f min reserved for depth; "
+                  "backlog: %d panos)"
+                  % (max_runtime_minutes, image_max_runtime, min_depth_runtime, depth_backlog))
+            if image_max_runtime == 0.0 and max_runtime_minutes > 0:
+                # Loud on stdout because cron mails it: without this, a zero-image night reads like ordinary
+                # budget exhaustion and a misconfigured fleet would silently stop downloading images.
+                print("WARNING: --min-depth-runtime (%g) >= --max-runtime (%g); NO images will be downloaded "
+                      "this run" % (min_depth_runtime, max_runtime_minutes))
+        else:
+            print("Budget: no unresolved depth work; image phase gets the full %.1f min"
+                  % (max_runtime_minutes,))
 
     with open(os.path.join(storage_location, "log.csv"), 'a') as log:
         log.write("\n%s" % (str(start_time)))
@@ -266,14 +283,13 @@ def run_scraper_and_log_results(image_pano_infos, depth_pano_infos, skip_depth, 
     with open(os.path.join(storage_location, "log.csv"), 'a') as log:
         log.write(",%d,%d,%d,%d,%d,%d" % (im_res[0], im_res[1], im_res[2], im_res[3], im_res[4], im_duration))
 
-    # Depth maps are GSV-only. This phase runs after the image phase and ends at the shared --max-runtime, so
-    # it gets the reserved tail plus whatever slack the image phase left. It iterates the full pano list — not
+    # The depth phase runs after the image phase and ends at the shared --max-runtime, so it gets the reserved
+    # tail (when one was taken) plus whatever slack the image phase left. It iterates the full pano list — not
     # the pano_id_log.csv-gated image loop, and not narrowed by --all-panos — which is what backfills depth for
     # panos downloaded in earlier runs and for panos nobody has labelled.
     if skip_depth:
         depth_res = (0, 0, 0, 0)
     else:
-        gsv_panos = [p for p in depth_pano_infos if p.get('source') == 'gsv']
         depth_res = gsv.download_depth_maps(storage_location, gsv_panos, start_time, max_runtime_minutes,
                                             max_depth_requests)
     depth_end_time = datetime.now()

--- a/DownloadRunner.py
+++ b/DownloadRunner.py
@@ -4,6 +4,7 @@ import argparse
 import http.client
 import json
 import logging
+import math
 import os
 import time
 from datetime import datetime
@@ -14,6 +15,21 @@ import pandas as pd
 from downloaders import DownloadResult, download_pano, gsv, mapillary
 
 
+def _reservation_minutes(value):
+    """argparse type= for --min-depth-runtime: a finite, non-negative float.
+
+    Without this, a negative value or nan silently made no reservation and inf silently zeroed the image
+    phase — a misconfiguration should fail the run at parse time, not misbehave quietly for months.
+    """
+    try:
+        minutes = float(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError("invalid float value: %r" % (value,))
+    if math.isnan(minutes) or math.isinf(minutes) or minutes < 0:
+        raise argparse.ArgumentTypeError("must be a finite, non-negative number of minutes: %r" % (value,))
+    return minutes
+
+
 parser = argparse.ArgumentParser()
 parser.add_argument('d', help='sidewalk_server_domain - FDQN of SidewalkWebpage server to fetch pano list from, i.e. sidewalk-columbus.cs.washington.edu')
 parser.add_argument('s', help='storage_path - location to store scraped panos')
@@ -21,7 +37,7 @@ parser.add_argument('-c', nargs='?', default=None, help='csv_path - location of 
 parser.add_argument('--all-panos', action='store_true', help='Download images for all panos that users visited, even if no labels were added on them. Does not affect depth, which always covers every pano.')
 parser.add_argument('--skip-depth', action='store_true', help='Skip downloading GSV depth maps (downloaded by default via the streetlevel library).')
 parser.add_argument('--max-runtime', type=float, default=None, metavar='MINUTES', help='Stop starting new downloads after this many minutes have elapsed.')
-parser.add_argument('--min-depth-runtime', type=float, default=0.0, metavar='MINUTES', help='Reserve the last MINUTES of --max-runtime for the depth phase when the depth ledger shows unresolved work, so an image backlog cannot starve depth. This is a reservation carved out of the image phase\'s start budget, not a hard floor on depth wall time: the image phase stops STARTING new panos once its share is spent (a pano already in flight can overrun into the reserved slice), and depth still ends at --max-runtime, so it also gets any slack images leave. If the reservation meets or exceeds --max-runtime, NO images are downloaded that run. Default 0 (no reservation); the production crontab should pass 60. Ignored without --max-runtime or with --skip-depth.')
+parser.add_argument('--min-depth-runtime', type=_reservation_minutes, default=0.0, metavar='MINUTES', help='Reserve the last MINUTES of --max-runtime for the depth phase when the depth ledger shows unresolved work, so an image backlog cannot starve depth. This is a reservation carved out of the image phase\'s start budget, not a hard floor on depth wall time: the image phase stops STARTING new panos once its share is spent (a pano already in flight can overrun into the reserved slice), and depth still ends at --max-runtime, so it also gets any slack images leave. If the reservation meets or exceeds --max-runtime, NO images are downloaded that run. Default 0 (no reservation); the production crontab should pass 60. Ignored without --max-runtime or with --skip-depth.')
 parser.add_argument('--max-depth-requests', type=int, default=None, metavar='N', help='Stop the depth phase after this many depth metadata requests.')
 # Deprecated no-op, kept for one release so existing invocations don't crash argparse.
 parser.add_argument('--attempt-depth', action='store_true', help=argparse.SUPPRESS)
@@ -39,6 +55,12 @@ max_depth_requests = args.max_depth_requests
 if args.attempt_depth:
     print("WARNING: --attempt-depth is deprecated and ignored; depth download is now on by default "
           "(use --skip-depth to disable).")
+
+# min_depth_runtime > 0 implies the operator typed the flag (the default is 0), so tell them when the
+# combination they ran it in means it cannot do anything.
+if min_depth_runtime > 0 and (max_runtime_minutes is None or skip_depth):
+    print("WARNING: --min-depth-runtime has no effect %s; no time will be reserved for the depth phase."
+          % ("with --skip-depth" if skip_depth else "without --max-runtime"))
 
 print(sidewalk_server_fqdn)
 print(storage_location)

--- a/DownloadRunner.py
+++ b/DownloadRunner.py
@@ -299,7 +299,11 @@ def run_scraper_and_log_results(image_pano_infos, depth_pano_infos, skip_depth, 
     with open(os.path.join(storage_location, "log.csv"), 'a') as log:
         log.write(",%d,%d,%d,%d,%d" % (xml_res[0], xml_res[1], xml_res[2], xml_res[3], xml_duration))
 
-    im_res = download_panorama_images(storage_location, image_pano_infos, start_time, image_max_runtime)
+    # The budget arguments are passed by keyword deliberately: two other open PRs rewrite these same call
+    # sites, and a positional merge resolution can put a datetime where a float belongs — a TypeError that only
+    # fires when --max-runtime is set, i.e. in the nightly cron and never in the suite.
+    im_res = download_panorama_images(storage_location, image_pano_infos, run_start_time=start_time,
+                                      max_runtime_minutes=image_max_runtime)
     im_end_time = datetime.now()
     im_duration = int(round((im_end_time - xml_end_time).total_seconds() / 60.0))
     with open(os.path.join(storage_location, "log.csv"), 'a') as log:
@@ -312,8 +316,9 @@ def run_scraper_and_log_results(image_pano_infos, depth_pano_infos, skip_depth, 
     if skip_depth:
         depth_res = (0, 0, 0, 0)
     else:
-        depth_res = gsv.download_depth_maps(storage_location, gsv_panos, start_time, max_runtime_minutes,
-                                            max_depth_requests)
+        depth_res = gsv.download_depth_maps(storage_location, gsv_panos, run_start_time=start_time,
+                                            max_runtime_minutes=max_runtime_minutes,
+                                            max_requests=max_depth_requests)
     depth_end_time = datetime.now()
     depth_duration = int(round((depth_end_time - im_end_time).total_seconds() / 60.0))
     with open(os.path.join(storage_location, "log.csv"), 'a') as log:
@@ -346,5 +351,5 @@ print("Panos: %d supported, %d eligible for image download, %d GSV panos eligibl
 
 # Use pano_id list and associated info to gather panos from respective APIs
 print("Fetching Panoramas")
-run_scraper_and_log_results(image_pano_infos, pano_infos, skip_depth, max_runtime_minutes, max_depth_requests,
-                            min_depth_runtime)
+run_scraper_and_log_results(image_pano_infos, pano_infos, skip_depth, max_runtime_minutes=max_runtime_minutes,
+                            max_depth_requests=max_depth_requests, min_depth_runtime=min_depth_runtime)

--- a/DownloadRunnerDockerEntrypoint.sh
+++ b/DownloadRunnerDockerEntrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # ./DownloadRunnerDockerEntrypoint sidewalk_server_fqdn [options]
 # ./DownloadRunnerDockerEntrypoint sidewalk_server_fqdn user@host:/remote/path port [options]
-# Options: --all-panos, --skip-depth, --max-runtime MINUTES, --max-depth-requests N
+# Options: --all-panos, --skip-depth, --max-runtime MINUTES, --min-depth-runtime MINUTES, --max-depth-requests N
 
 mkdir -p /tmp/download_dest
 if [ -f /app/id_rsa ]; then
@@ -12,6 +12,7 @@ fi
 all_panos=""
 skip_depth=""
 max_runtime=""
+min_depth_runtime=""
 max_depth_requests=""
 
 # Process arguments from the end
@@ -36,6 +37,9 @@ while [[ $# -gt 0 ]]; do
             if [[ $# -ge 2 && "${@: -2:1}" == "--max-runtime" ]]; then
                 max_runtime="--max-runtime ${@: -1}"
                 set -- "${@:1:$(($#-2))}"
+            elif [[ $# -ge 2 && "${@: -2:1}" == "--min-depth-runtime" ]]; then
+                min_depth_runtime="--min-depth-runtime ${@: -1}"
+                set -- "${@:1:$(($#-2))}"
             elif [[ $# -ge 2 && "${@: -2:1}" == "--max-depth-requests" ]]; then
                 max_depth_requests="--max-depth-requests ${@: -1}"
                 set -- "${@:1:$(($#-2))}"
@@ -50,13 +54,13 @@ done
 # parsed but not forwarded is silently ignored.
 # If one param, just download to /tmp. If three params, this means a host and port has been supplied.
 if [ $# -eq 1 ]; then
-    python3 DownloadRunner.py $1 /tmp/download_dest $all_panos $skip_depth $max_runtime $max_depth_requests
+    python3 DownloadRunner.py $1 /tmp/download_dest $all_panos $skip_depth $max_runtime $min_depth_runtime $max_depth_requests
 elif [ $# -eq 3 ]; then
     echo "Mounting $2 port $3 for $1"
-    sshfs -o IdentityFile=/app/id_rsa,StrictHostKeyChecking=no $2 /tmp/download_dest -p $3 && python3 DownloadRunner.py $1 /tmp/download_dest $all_panos $skip_depth $max_runtime $max_depth_requests; umount /tmp/download_dest
+    sshfs -o IdentityFile=/app/id_rsa,StrictHostKeyChecking=no $2 /tmp/download_dest -p $3 && python3 DownloadRunner.py $1 /tmp/download_dest $all_panos $skip_depth $max_runtime $min_depth_runtime $max_depth_requests; umount /tmp/download_dest
 else
     echo "Usage:"
     echo "  ./DownloadRunnerDockerEntrypoint sidewalk_server_fqdn [options]"
     echo "  ./DownloadRunnerDockerEntrypoint sidewalk_server_fqdn user@host:/remote/path port [options]"
-    echo "Options: --all-panos, --skip-depth, --max-runtime MINUTES, --max-depth-requests N"
+    echo "Options: --all-panos, --skip-depth, --max-runtime MINUTES, --min-depth-runtime MINUTES, --max-depth-requests N"
 fi

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ There are two main scripts of note: [DownloadRunner.py](DownloadRunner.py) and [
 Optional flags (accepted both by `DownloadRunner.py` and, appended after the positional args, by the Docker entrypoint):
 * `--all-panos` — download *images* for panos that users visited but never labeled. This does not affect depth, which always covers every pano (see [Depth Maps](#depth-maps)).
 * `--skip-depth` — skip the GSV depth-map phase (on by default; see [Depth Maps](#depth-maps)).
-* `--max-runtime MINUTES` — stop starting new downloads/requests after this much wall time (the daily cron uses this).
+* `--max-runtime MINUTES` — stop starting new downloads/requests after this much wall time (the daily cron uses this; it exists to keep a run inside its daily slot, see [#38](https://github.com/ProjectSidewalk/sidewalk-panorama-tools/issues/38)).
+* `--min-depth-runtime MINUTES` — reserve the last MINUTES of `--max-runtime` for the depth phase (default 60). The image phase stops early enough to leave depth this slice, so an image backlog can't starve the depth backfill; depth still runs until `--max-runtime`, so it also gets any slack images leave. Ignored without `--max-runtime` or with `--skip-depth`; pass 0 to let images use the whole budget.
 * `--max-depth-requests N` — stop the depth phase after N metadata requests (useful to throttle the initial backfill).
 
 Additional settings can be configured for `DownloadRunner.py` in the configuration file `config.py`. 
@@ -154,7 +155,7 @@ Artifacts and bookkeeping, relative to the storage root:
   ```
 * `depth_log.csv` — an append-only ledger (`pano_id,status`) of resolved outcomes: `saved` (artifact written) or `unavailable` (pano gone from Google, or no depth payload). Ledgered panos are never re-requested; transient network failures are *not* ledgered, so they retry on the next run. The artifacts on disk are the ground truth — deleting the ledger is safe and just makes the next run re-check everything (existing artifacts are re-registered without re-downloading).
 
-The depth phase runs after the image phase and shares its `--max-runtime` budget, so on a fresh city (or the first runs after this feature) images download first and depth backfills incrementally across daily runs. Use `--max-depth-requests` to cap the phase's request volume during backfill.
+The depth phase runs after the image phase, and the two share one `--max-runtime` budget — that flag bounds the whole run to its daily cron slot, and the slot doesn't care which phase spends the clock. Within it, `--min-depth-runtime` (default 60) reserves the tail of the budget for depth: the image phase must stop at `max-runtime − min-depth-runtime`, so a big image backlog (a mapathon influx — which is also exactly when many new panos want depth) cannot starve the backfill night after night. On light nights images finish early and depth gets the slack too. Use `--max-depth-requests` to cap the phase's request volume during backfill.
 
 ### Being a good citizen of Google's servers
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,15 @@ Optional flags (accepted both by `DownloadRunner.py` and, appended after the pos
 * `--all-panos` — download *images* for panos that users visited but never labeled. This does not affect depth, which always covers every pano (see [Depth Maps](#depth-maps)).
 * `--skip-depth` — skip the GSV depth-map phase (on by default; see [Depth Maps](#depth-maps)).
 * `--max-runtime MINUTES` — stop starting new downloads/requests after this much wall time (the daily cron uses this; it exists to keep a run inside its daily slot, see [#38](https://github.com/ProjectSidewalk/sidewalk-panorama-tools/issues/38)).
-* `--min-depth-runtime MINUTES` — reserve the last MINUTES of `--max-runtime` for the depth phase (default 60). The image phase stops early enough to leave depth this slice, so an image backlog can't starve the depth backfill; depth still runs until `--max-runtime`, so it also gets any slack images leave. Ignored without `--max-runtime` or with `--skip-depth`; pass 0 to let images use the whole budget.
+* `--min-depth-runtime MINUTES` — reserve the last MINUTES of `--max-runtime` for the depth phase when there is unresolved depth work, so an image backlog can't starve the depth backfill (see [Depth Maps](#depth-maps) for the exact semantics). Default 0 (no reservation); **the recommended production crontab value is `--min-depth-runtime 60`**. Ignored without `--max-runtime` or with `--skip-depth`. Beware: if the reservation meets or exceeds `--max-runtime`, the run downloads **no images** (it prints a loud `WARNING`).
 * `--max-depth-requests N` — stop the depth phase after N metadata requests (useful to throttle the initial backfill).
+
+For the nightly production crontab, append `--max-runtime` sized to the cron slot plus the recommended depth reservation, e.g.:
+```
+docker run --cap-add SYS_ADMIN --device=/dev/fuse --security-opt apparmor:unconfined \
+  projectsidewalk/scraper:v6 <project-sidewalk-url> <user@host:/remote/path> <port> \
+  --max-runtime 360 --min-depth-runtime 60
+```
 
 Additional settings can be configured for `DownloadRunner.py` in the configuration file `config.py`. 
 * `thread_count` - the number of threads you wish to run in parallel. As this uses asyncio and is an I/O task, the higher the count the faster the operation, but you will need to test what the upper limit is for your own device and network connection.
@@ -155,7 +162,13 @@ Artifacts and bookkeeping, relative to the storage root:
   ```
 * `depth_log.csv` — an append-only ledger (`pano_id,status`) of resolved outcomes: `saved` (artifact written) or `unavailable` (pano gone from Google, or no depth payload). Ledgered panos are never re-requested; transient network failures are *not* ledgered, so they retry on the next run. The artifacts on disk are the ground truth — deleting the ledger is safe and just makes the next run re-check everything (existing artifacts are re-registered without re-downloading).
 
-The depth phase runs after the image phase, and the two share one `--max-runtime` budget — that flag bounds the whole run to its daily cron slot, and the slot doesn't care which phase spends the clock. Within it, `--min-depth-runtime` (default 60) reserves the tail of the budget for depth: the image phase must stop at `max-runtime − min-depth-runtime`, so a big image backlog (a mapathon influx — which is also exactly when many new panos want depth) cannot starve the backfill night after night. On light nights images finish early and depth gets the slack too. Use `--max-depth-requests` to cap the phase's request volume during backfill.
+The depth phase runs after the image phase, and the two share one `--max-runtime` budget — that flag bounds the whole run to its daily cron slot, and the slot doesn't care which phase spends the clock. Because images run first, a big image backlog (a mapathon influx — which is also exactly when many new panos want depth) could starve the backfill night after night. `--min-depth-runtime` (default 0, i.e. off; the production crontab should pass 60) counters that by reserving the tail of the budget for depth whenever `depth_log.csv` shows unresolved work: the image phase then stops *starting* new panos at `max-runtime − min-depth-runtime`. Three consequences worth knowing:
+
+* **It is a reservation, not a hard floor on depth wall time.** A pano already downloading when the image share runs out finishes anyway (eating into the reserved slice), and depth still ends at `--max-runtime` — on light nights images finish early and depth also gets the slack.
+* **It only applies while depth has work.** Once every GSV pano is resolved in `depth_log.csv`, no time is reserved and the image phase keeps the whole budget.
+* **A reservation at or above `--max-runtime` zeroes the image phase.** The run then downloads **no images** and prints `WARNING: --min-depth-runtime (X) >= --max-runtime (Y); NO images will be downloaded this run`, so a misconfigured crontab shows up in cron mail instead of looking like ordinary budget exhaustion.
+
+Use `--max-depth-requests` to cap the phase's request volume during backfill.
 
 ### Being a good citizen of Google's servers
 

--- a/downloaders/gsv.py
+++ b/downloaders/gsv.py
@@ -310,6 +310,29 @@ def _load_depth_log(depth_log_path):
     return resolved
 
 
+def count_unresolved_depth(storage_path, pano_infos):
+    """Count panos whose depth outcome is not yet recorded in the depth ledger.
+
+    A cheap local read of depth_log.csv (see _load_depth_log) — no network. DownloadRunner uses it to decide
+    whether --min-depth-runtime should reserve image time at all: with nothing unresolved the depth phase
+    returns in milliseconds, so a reservation would just burn image throughput.
+
+    A pano whose artifact exists but whose ledger row is missing (only possible after manual ledger surgery)
+    counts as unresolved even though the phase will self-heal it without a request; that inaccuracy is not
+    worth a directory walk here. An unreadable ledger counts as no backlog: download_depth_maps sits the run
+    out in that state, so there is nothing to reserve for.
+
+    @param storage_path Root of the pano store (depth_log.csv lives here).
+    @param pano_infos   Pano dicts (needs 'pano_id'); callers pre-filter to source == 'gsv'.
+    @return             Number of panos with no 'saved'/'unavailable' ledger row.
+    """
+    try:
+        resolved = _load_depth_log(os.path.join(storage_path, DEPTH_LOG_FILENAME))
+    except OSError:
+        return 0
+    return sum(1 for p in pano_infos if p['pano_id'] not in resolved)
+
+
 def _write_depth_artifact(storage_path, pano_id, pano):
     """Atomically write <pano_id[:2]>/<pano_id>.depth.npz for a streetlevel pano with depth data.
 

--- a/tests/test_depth_phase.py
+++ b/tests/test_depth_phase.py
@@ -329,6 +329,35 @@ def test_persistent_failures_cannot_starve_the_request_budget(tmp_path, fake_str
     assert len(attempted) > 5
 
 
+class TestCountUnresolvedDepth:
+    """count_unresolved_depth backs DownloadRunner's decision to reserve image time for depth at all: a
+    reservation with nothing unresolved would burn image throughput for a phase that returns in milliseconds."""
+
+    def test_counts_everything_with_no_ledger(self, tmp_path):
+        assert gsv.count_unresolved_depth(str(tmp_path), pano_infos('aaaaaa', 'bbbbbb')) == 2
+
+    def test_resolved_panos_do_not_count(self, tmp_path):
+        with open(os.path.join(str(tmp_path), gsv.DEPTH_LOG_FILENAME), 'w', newline='') as f:
+            f.write('pano_id,status\naaaaaa,saved\nbbbbbb,unavailable\n')
+        assert gsv.count_unresolved_depth(str(tmp_path), pano_infos('aaaaaa', 'bbbbbb', 'cccccc')) == 1
+
+    def test_malformed_ledger_rows_count_as_unresolved(self, tmp_path):
+        # Same tolerance as _load_depth_log: a crash-truncated row means the pano will be re-requested, so it
+        # is real depth work and must count toward the backlog.
+        with open(os.path.join(str(tmp_path), gsv.DEPTH_LOG_FILENAME), 'w', newline='') as f:
+            f.write('pano_id,status\nbbbbbb,saved\naaaaaa\n')
+        assert gsv.count_unresolved_depth(str(tmp_path), pano_infos('aaaaaa', 'bbbbbb')) == 1
+
+    def test_unreadable_ledger_counts_as_no_backlog(self, tmp_path, monkeypatch):
+        """When the ledger can't be read, download_depth_maps sits the run out — nothing to reserve for."""
+
+        def boom(path):
+            raise OSError(5, 'Input/output error')
+
+        monkeypatch.setattr(gsv, '_load_depth_log', boom)
+        assert gsv.count_unresolved_depth(str(tmp_path), pano_infos('aaaaaa')) == 0
+
+
 def test_missing_streetlevel_returns_zeros(tmp_path, monkeypatch):
     storage = str(tmp_path)
     # None in sys.modules makes `from streetlevel import streetview` raise ImportError.

--- a/tests/test_download_runner.py
+++ b/tests/test_download_runner.py
@@ -1,16 +1,21 @@
 """Subprocess tests for DownloadRunner.py.
 
-The pano CSV rows all use an unsupported source, so every pano is filtered out before any phase runs — the
-script exercises its full argument parsing, phase orchestration, and log.csv writing without any network I/O.
+Two pano CSVs are used. The unsupported-source CSV filters every pano out before any phase runs, so those
+tests exercise argument parsing, phase orchestration, and log.csv writing with no network I/O. The gsv-source
+CSV feeds the budget tests: those runs stub the per-pano download via a driver script (and cap the depth phase
+at 0 requests), so they count what the image phase actually downloads — still with no network I/O.
 """
 
+import logging
 import os
 import subprocess
 import sys
+from datetime import datetime
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 RUNNER = os.path.join(REPO_ROOT, 'DownloadRunner.py')
 CSV_HEADER = 'pano_id,width,height,lat,lng,camera_heading,camera_pitch,source,has_labels\n'
+GSV_PANO_IDS = ['testPanoIdGsvAAAAAAAAA', 'testPanoIdGsvBBBBBBBBB']
 
 
 def write_pano_csv(tmp_path):
@@ -107,6 +112,146 @@ class TestDepthBudgetFloor:
         storage, result = run_downloader(tmp_path)
         assert result.returncode == 0, result.stderr
         assert 'reserved for depth' not in result.stdout
+
+
+def write_gsv_csv(tmp_path):
+    """Two labelled GSV panos — a supported source, so they reach the image phase's budget guard."""
+    csv_path = tmp_path / 'gsv_panos.csv'
+    csv_path.write_text(CSV_HEADER
+                        + '%s,16384,8192,47.6,-122.3,180.0,0.0,gsv,True\n' % GSV_PANO_IDS[0]
+                        + '%s,16384,8192,47.7,-122.4,90.0,0.0,gsv,True\n' % GSV_PANO_IDS[1])
+    return str(csv_path)
+
+
+FAKE_NETWORK_DRIVER = '''\
+"""Test-only driver: run the real DownloadRunner.py with the per-pano image download stubbed.
+
+Records each pano "downloaded" to $FAKE_DOWNLOAD_LOG instead of touching the network, then executes
+DownloadRunner.py itself (argparse, phase orchestration, budget arithmetic, log.csv) unmodified via runpy.
+"""
+import os
+import runpy
+import sys
+
+sys.path.insert(0, %(repo_root)r)
+
+import downloaders
+from downloaders import DownloadResult
+
+
+def _fake_download_pano(storage_path, pano_info):
+    with open(os.environ['FAKE_DOWNLOAD_LOG'], 'a') as f:
+        f.write(pano_info['pano_id'] + '\\n')
+    return DownloadResult.success
+
+
+downloaders.download_pano = _fake_download_pano
+sys.argv = ['DownloadRunner.py'] + sys.argv[1:]
+runpy.run_path(%(runner)r)
+''' % {'repo_root': REPO_ROOT, 'runner': RUNNER}
+
+
+def run_downloader_with_fake_network(tmp_path, *extra_args):
+    """Drive the real DownloadRunner.py against the gsv-source CSV, counting image downloads.
+
+    The unsupported-source CSV never reaches the budget guard (every pano is filtered out before the image
+    loop), which is how announcement-only tests could pass while the budget split itself was mutated away.
+    These runs use supported panos with download_pano stubbed by FAKE_NETWORK_DRIVER, and --max-depth-requests 0
+    so the depth phase issues no requests either — the download counts reflect the real budget arithmetic, with
+    zero network I/O.
+    """
+    driver = tmp_path / 'fake_network_driver.py'
+    driver.write_text(FAKE_NETWORK_DRIVER)
+    downloads_log = tmp_path / 'downloads.txt'
+    downloads_log.write_text('')
+    storage = tmp_path / 'storage'
+    env = dict(os.environ, FAKE_DOWNLOAD_LOG=str(downloads_log))
+    result = subprocess.run(
+        [sys.executable, str(driver), 'sidewalk-test.invalid', str(storage), '-c', write_gsv_csv(tmp_path),
+         '--max-depth-requests', '0', *extra_args],
+        cwd=str(tmp_path), capture_output=True, text=True, timeout=120, env=env)
+    downloaded = downloads_log.read_text().split()
+    return storage, result, downloaded
+
+
+class TestImageBudgetBehaviour:
+    """What the image phase actually downloads under a --min-depth-runtime reservation (#43).
+
+    The review demonstrated that pinning only the budget announcement lets feature-deleting mutations pass the
+    whole suite; these tests assert on the downloads themselves.
+    """
+
+    def test_reservation_that_consumes_the_budget_downloads_no_images(self, tmp_path):
+        storage, result, downloaded = run_downloader_with_fake_network(
+            tmp_path, '--max-runtime', '5', '--min-depth-runtime', '5')
+        assert result.returncode == 0, result.stderr
+        assert downloaded == []
+
+    def test_zero_reservation_downloads_every_pano(self, tmp_path):
+        storage, result, downloaded = run_downloader_with_fake_network(
+            tmp_path, '--max-runtime', '5', '--min-depth-runtime', '0')
+        assert result.returncode == 0, result.stderr
+        assert sorted(downloaded) == sorted(GSV_PANO_IDS)
+
+
+def import_download_runner(tmp_path, monkeypatch):
+    """Import DownloadRunner as a module so download_panorama_images can be unit-tested directly.
+
+    The script has no main() — argparse and a full run execute at import — so argv is pointed at the
+    network-free unsupported-source CSV with --skip-depth first, and the module cache is cleared so every test
+    imports (and therefore runs) afresh.
+    """
+    monkeypatch.setattr(sys, 'argv',
+                        ['DownloadRunner.py', 'sidewalk-test.invalid', str(tmp_path / 'import_storage'),
+                         '-c', write_pano_csv(tmp_path), '--skip-depth'])
+    monkeypatch.chdir(tmp_path)  # the import-time run and the calls below write scrape.log to cwd
+    if not logging.getLogger().handlers:
+        # Keep download_panorama_images' logging.basicConfig from opening scrape.log for the whole session,
+        # which would pin the tmp dir on Windows.
+        logging.getLogger().addHandler(logging.NullHandler())
+    sys.modules.pop('DownloadRunner', None)
+    import DownloadRunner
+    return DownloadRunner
+
+
+class TestDownloadPanoramaImagesBudget:
+    """Direct tests of the image phase's budget guard — the review found it had no unit tests at all."""
+
+    def stub_downloads(self, runner, monkeypatch):
+        calls = []
+
+        def fake_download_pano(storage_path, pano_info):
+            calls.append(pano_info['pano_id'])
+            return runner.DownloadResult.success
+
+        monkeypatch.setattr(runner, 'download_pano', fake_download_pano)
+        return calls
+
+    def test_zero_budget_downloads_nothing(self, tmp_path, monkeypatch):
+        runner = import_download_runner(tmp_path, monkeypatch)
+        calls = self.stub_downloads(runner, monkeypatch)
+        storage = tmp_path / 'direct_storage'
+        storage.mkdir()
+        panos = [{'pano_id': p, 'source': 'gsv'} for p in GSV_PANO_IDS]
+
+        result = runner.download_panorama_images(str(storage), panos, run_start_time=datetime.now(),
+                                                 max_runtime_minutes=0.0)
+
+        assert calls == []
+        assert result == (0, 0, 0, 0, 0)
+
+    def test_no_budget_downloads_every_pano(self, tmp_path, monkeypatch):
+        runner = import_download_runner(tmp_path, monkeypatch)
+        calls = self.stub_downloads(runner, monkeypatch)
+        storage = tmp_path / 'direct_storage'
+        storage.mkdir()
+        panos = [{'pano_id': p, 'source': 'gsv'} for p in GSV_PANO_IDS]
+
+        result = runner.download_panorama_images(str(storage), panos, run_start_time=datetime.now(),
+                                                 max_runtime_minutes=None)
+
+        assert sorted(calls) == sorted(GSV_PANO_IDS)
+        assert result == (2, 0, 0, 0, 2)
 
 
 def write_mixed_label_csv(tmp_path):

--- a/tests/test_download_runner.py
+++ b/tests/test_download_runner.py
@@ -69,6 +69,46 @@ def test_max_depth_requests_flag_is_accepted(tmp_path):
     assert len(last_log_fields(storage)) == 18
 
 
+class TestDepthBudgetFloor:
+    """--min-depth-runtime reserves the tail of --max-runtime for the depth phase (#43).
+
+    Without a reservation, the images-first shared budget lets an image backlog (a mapathon is the #38
+    scenario) starve the depth backfill night after night - exactly when the most new panos arrive. All runs
+    here use the unsupported-source CSV, so both phases see empty pano lists and nothing touches the network;
+    the assertions read the budget-split line the run prints for cron mail.
+    """
+
+    def test_default_reserves_an_hour_for_depth(self, tmp_path):
+        storage, result = run_downloader(tmp_path, '--max-runtime', '120')
+        assert result.returncode == 0, result.stderr
+        assert 'image phase capped at 60.0 min (60.0 reserved for depth)' in result.stdout
+
+    def test_flag_sets_the_reservation(self, tmp_path):
+        storage, result = run_downloader(tmp_path, '--max-runtime', '120', '--min-depth-runtime', '45')
+        assert result.returncode == 0, result.stderr
+        assert 'image phase capped at 75.0 min (45.0 reserved for depth)' in result.stdout
+
+    def test_zero_floor_restores_the_old_behaviour(self, tmp_path):
+        storage, result = run_downloader(tmp_path, '--max-runtime', '120', '--min-depth-runtime', '0')
+        assert result.returncode == 0, result.stderr
+        assert 'reserved for depth' not in result.stdout
+
+    def test_floor_larger_than_total_clamps_image_budget_to_zero(self, tmp_path):
+        storage, result = run_downloader(tmp_path, '--max-runtime', '30')
+        assert result.returncode == 0, result.stderr
+        assert 'image phase capped at 0.0 min (60.0 reserved for depth)' in result.stdout
+
+    def test_skip_depth_gives_images_the_whole_budget(self, tmp_path):
+        storage, result = run_downloader(tmp_path, '--max-runtime', '120', '--skip-depth')
+        assert result.returncode == 0, result.stderr
+        assert 'reserved for depth' not in result.stdout
+
+    def test_no_max_runtime_means_no_reservation(self, tmp_path):
+        storage, result = run_downloader(tmp_path)
+        assert result.returncode == 0, result.stderr
+        assert 'reserved for depth' not in result.stdout
+
+
 def write_mixed_label_csv(tmp_path):
     """Two GSV panos, only one of which carries labels."""
     csv_path = tmp_path / 'mixed.csv'

--- a/tests/test_download_runner.py
+++ b/tests/test_download_runner.py
@@ -74,34 +74,31 @@ def test_max_depth_requests_flag_is_accepted(tmp_path):
     assert len(last_log_fields(storage)) == 18
 
 
-class TestDepthBudgetFloor:
-    """--min-depth-runtime reserves the tail of --max-runtime for the depth phase (#43).
-
-    Without a reservation, the images-first shared budget lets an image backlog (a mapathon is the #38
-    scenario) starve the depth backfill night after night - exactly when the most new panos arrive. All runs
-    here use the unsupported-source CSV, so both phases see empty pano lists and nothing touches the network;
-    the assertions read the budget-split line the run prints for cron mail.
+class TestDepthBudgetMessages:
+    """stdout messages for the --min-depth-runtime budget split (cron mails stdout, so these lines are the
+    operator's only signal). What the split actually *does* is pinned in TestImageBudgetBehaviour below —
+    these runs use the unsupported-source CSV, so both phases see empty pano lists.
     """
 
-    def test_default_reserves_an_hour_for_depth(self, tmp_path):
+    def test_default_makes_no_reservation(self, tmp_path):
+        # The fleet plans to drastically lower --max-runtime; a default reservation would silently zero the
+        # image phase on every city whose slot is at or under it. Reserving is opt-in.
         storage, result = run_downloader(tmp_path, '--max-runtime', '120')
         assert result.returncode == 0, result.stderr
-        assert 'image phase capped at 60.0 min (60.0 reserved for depth)' in result.stdout
+        assert 'reserved for depth' not in result.stdout
+        assert 'NO images' not in result.stdout
 
-    def test_flag_sets_the_reservation(self, tmp_path):
+    def test_no_backlog_means_no_reservation(self, tmp_path):
+        # No gsv panos in this CSV, so the depth ledger has no unresolved work to reserve for.
         storage, result = run_downloader(tmp_path, '--max-runtime', '120', '--min-depth-runtime', '45')
         assert result.returncode == 0, result.stderr
-        assert 'image phase capped at 75.0 min (45.0 reserved for depth)' in result.stdout
+        assert 'no unresolved depth work' in result.stdout
+        assert 'reserved for depth' not in result.stdout
 
-    def test_zero_floor_restores_the_old_behaviour(self, tmp_path):
+    def test_zero_reservation_is_silent(self, tmp_path):
         storage, result = run_downloader(tmp_path, '--max-runtime', '120', '--min-depth-runtime', '0')
         assert result.returncode == 0, result.stderr
         assert 'reserved for depth' not in result.stdout
-
-    def test_floor_larger_than_total_clamps_image_budget_to_zero(self, tmp_path):
-        storage, result = run_downloader(tmp_path, '--max-runtime', '30')
-        assert result.returncode == 0, result.stderr
-        assert 'image phase capped at 0.0 min (60.0 reserved for depth)' in result.stdout
 
     def test_skip_depth_gives_images_the_whole_budget(self, tmp_path):
         storage, result = run_downloader(tmp_path, '--max-runtime', '120', '--skip-depth')
@@ -186,12 +183,48 @@ class TestImageBudgetBehaviour:
             tmp_path, '--max-runtime', '5', '--min-depth-runtime', '5')
         assert result.returncode == 0, result.stderr
         assert downloaded == []
+        # A zero-image run must be unmistakable in cron mail, not read like ordinary budget exhaustion.
+        assert ('WARNING: --min-depth-runtime (5) >= --max-runtime (5); NO images will be downloaded this run'
+                in result.stdout)
 
     def test_zero_reservation_downloads_every_pano(self, tmp_path):
         storage, result, downloaded = run_downloader_with_fake_network(
             tmp_path, '--max-runtime', '5', '--min-depth-runtime', '0')
         assert result.returncode == 0, result.stderr
         assert sorted(downloaded) == sorted(GSV_PANO_IDS)
+
+    def test_default_reserves_nothing(self, tmp_path):
+        # Same run as above but with --min-depth-runtime left at its default, which must be 0: the fleet plans
+        # to drastically lower --max-runtime, and a default reservation would zero the image phase fleet-wide.
+        storage, result, downloaded = run_downloader_with_fake_network(tmp_path, '--max-runtime', '5')
+        assert result.returncode == 0, result.stderr
+        assert sorted(downloaded) == sorted(GSV_PANO_IDS)
+
+    def test_fully_resolved_depth_ledger_frees_the_whole_budget_for_images(self, tmp_path):
+        # The reservation exists to protect a depth *backlog*. Once every pano is resolved in the ledger the
+        # depth phase returns in milliseconds, so reserving would burn image throughput for nothing — the image
+        # phase must get the full budget even with --min-depth-runtime set.
+        storage = tmp_path / 'storage'
+        storage.mkdir()
+        (storage / 'depth_log.csv').write_text(
+            'pano_id,status\n%s,saved\n%s,unavailable\n' % (GSV_PANO_IDS[0], GSV_PANO_IDS[1]))
+
+        storage, result, downloaded = run_downloader_with_fake_network(
+            tmp_path, '--max-runtime', '5', '--min-depth-runtime', '5')
+
+        assert result.returncode == 0, result.stderr
+        assert sorted(downloaded) == sorted(GSV_PANO_IDS)
+        assert 'no unresolved depth work' in result.stdout
+        assert 'NO images' not in result.stdout
+
+    def test_backlog_applies_the_reservation_and_announces_it(self, tmp_path):
+        # Nothing in the ledger, so both gsv panos are a depth backlog: the reservation must be taken.
+        storage, result, downloaded = run_downloader_with_fake_network(
+            tmp_path, '--max-runtime', '120', '--min-depth-runtime', '45')
+        assert result.returncode == 0, result.stderr
+        # The image phase still has 75 minutes — plenty for two stubbed panos.
+        assert sorted(downloaded) == sorted(GSV_PANO_IDS)
+        assert 'image phase capped at 75.0 min' in result.stdout
 
 
 def import_download_runner(tmp_path, monkeypatch):

--- a/tests/test_download_runner.py
+++ b/tests/test_download_runner.py
@@ -12,6 +12,8 @@ import subprocess
 import sys
 from datetime import datetime
 
+import pytest
+
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 RUNNER = os.path.join(REPO_ROOT, 'DownloadRunner.py')
 CSV_HEADER = 'pano_id,width,height,lat,lng,camera_heading,camera_pitch,source,has_labels\n'
@@ -109,6 +111,34 @@ class TestDepthBudgetMessages:
         storage, result = run_downloader(tmp_path)
         assert result.returncode == 0, result.stderr
         assert 'reserved for depth' not in result.stdout
+
+
+class TestMinDepthRuntimeValidation:
+    """--min-depth-runtime inputs that would otherwise silently no-op or zero the image phase (#43 review):
+    -5 and nan silently made no reservation, inf silently zeroed the image phase. Reject them at parse time,
+    and tell an operator who typed the flag in a combination where it cannot apply."""
+
+    @pytest.mark.parametrize('bad', ['-5', 'nan', 'inf', '-inf', 'abc'])
+    def test_rejects_negative_nan_and_inf(self, tmp_path, bad):
+        storage, result = run_downloader(tmp_path, '--max-runtime', '120', '--min-depth-runtime', bad)
+        assert result.returncode == 2
+        assert '--min-depth-runtime' in result.stderr
+
+    def test_warns_when_given_without_max_runtime(self, tmp_path):
+        storage, result = run_downloader(tmp_path, '--min-depth-runtime', '45')
+        assert result.returncode == 0, result.stderr
+        assert 'WARNING: --min-depth-runtime has no effect without --max-runtime' in result.stdout
+
+    def test_warns_when_given_with_skip_depth(self, tmp_path):
+        storage, result = run_downloader(tmp_path, '--max-runtime', '120', '--min-depth-runtime', '45',
+                                         '--skip-depth')
+        assert result.returncode == 0, result.stderr
+        assert 'WARNING: --min-depth-runtime has no effect with --skip-depth' in result.stdout
+
+    def test_effective_combination_does_not_warn(self, tmp_path):
+        storage, result = run_downloader(tmp_path, '--max-runtime', '120', '--min-depth-runtime', '45')
+        assert result.returncode == 0, result.stderr
+        assert 'has no effect' not in result.stdout
 
 
 def write_gsv_csv(tmp_path):

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -50,6 +50,12 @@ def test_forwards_all_optional_flags(run_entrypoint):
     assert forwarded[forwarded.index('--max-depth-requests') + 1] == '100'
 
 
+def test_forwards_min_depth_runtime(run_entrypoint):
+    result, forwarded = run_entrypoint('sidewalk-test.invalid', '--min-depth-runtime', '45')
+    assert result.returncode == 0
+    assert forwarded[forwarded.index('--min-depth-runtime') + 1] == '45'
+
+
 def test_forwards_skip_depth(run_entrypoint):
     result, forwarded = run_entrypoint('sidewalk-test.invalid', '--skip-depth')
     assert result.returncode == 0

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -40,6 +40,48 @@ def run_entrypoint(tmp_path):
     return run
 
 
+@pytest.fixture
+def run_entrypoint_sshfs(tmp_path):
+    """Run the 3-arg (sshfs-mounted) entrypoint path — the production invocation — with sshfs, umount, and
+    python3 all stubbed on PATH."""
+    stub_dir = tmp_path / 'bin'
+    stub_dir.mkdir()
+    capture_file = tmp_path / 'python3-args.txt'
+    sshfs_file = tmp_path / 'sshfs-args.txt'
+    (stub_dir / 'python3').write_text('#!/bin/bash\necho "$@" > "$CAPTURE_FILE"\n')
+    (stub_dir / 'sshfs').write_text('#!/bin/bash\necho "$@" > "$SSHFS_FILE"\n')
+    (stub_dir / 'umount').write_text('#!/bin/bash\nexit 0\n')
+    for stub in ('python3', 'sshfs', 'umount'):
+        (stub_dir / stub).chmod(0o755)
+
+    def run(*args):
+        env = dict(os.environ,
+                   PATH=f"{stub_dir}:{os.environ['PATH']}",
+                   CAPTURE_FILE=str(capture_file),
+                   SSHFS_FILE=str(sshfs_file))
+        result = subprocess.run(['bash', ENTRYPOINT, *args],
+                                cwd=str(tmp_path), env=env, capture_output=True, text=True, timeout=30)
+        forwarded = capture_file.read_text().split() if capture_file.exists() else None
+        mounted = sshfs_file.read_text().split() if sshfs_file.exists() else None
+        return result, forwarded, mounted
+
+    return run
+
+
+def test_sshfs_path_forwards_the_budget_flags(run_entrypoint_sshfs):
+    """The sshfs invocation is the one production runs; a flag parsed but dropped only from that line would
+    pass every 1-arg test here and still silently disable the feature fleet-wide (it has happened before —
+    see the entrypoint's own comment)."""
+    result, forwarded, mounted = run_entrypoint_sshfs(
+        'sidewalk-test.invalid', 'user@host.invalid:/remote/path', '2222',
+        '--max-runtime', '5', '--min-depth-runtime', '45')
+    assert result.returncode == 0
+    assert mounted is not None and 'user@host.invalid:/remote/path' in mounted
+    assert forwarded[:3] == ['DownloadRunner.py', 'sidewalk-test.invalid', '/tmp/download_dest']
+    assert forwarded[forwarded.index('--max-runtime') + 1] == '5'
+    assert forwarded[forwarded.index('--min-depth-runtime') + 1] == '45'
+
+
 def test_forwards_all_optional_flags(run_entrypoint):
     result, forwarded = run_entrypoint('sidewalk-test.invalid', '--all-panos', '--max-runtime', '5',
                                        '--max-depth-requests', '100')


### PR DESCRIPTION
Addresses the budget question in #43 (doesn't close it — the SFTP-capacity and rollout questions remain).

## Design

Per the discussion: `--max-runtime` keeps its #38 meaning — bound the whole run to its daily cron slot, a constraint that is phase-fungible, so the total stays shared rather than splitting into independent per-phase caps (whose sum you'd have to fit into the slot anyway). What changes is the allocation *inside* it:

* **New `--min-depth-runtime MINUTES`, default 60.** The image phase must stop at `max-runtime − reservation`, so depth is guaranteed its slice. Depth still ends at the total, so slack from a light image night rolls to depth instead of being lost — during backfill, most nights depth will get far more than the floor.
* **Why a floor matters:** with images-first and no reservation, an image backlog starves depth completely — and the mapathon influx #38 describes is exactly when thousands of new panos arrive wanting depth. After backfill completes the reservation costs nothing: the depth phase exits when its queue is empty, and only new panos remain nightly.
* **Edge semantics:** ignored when `--max-runtime` is unset (nothing is bounded then anyway) and under `--skip-depth`; image cap clamps at 0 when the floor exceeds the total; explicit `0` restores the old behavior. Endpoint-facing politeness is untouched — that already lives per-endpoint (depth pacing/circuit breaker/`--max-depth-requests`; image retry/backoff).
* The run prints `Budget: X min total; image phase capped at Y min (Z reserved for depth)` so the cron mail shows the split.

**Note on the default:** 60 is a deliberate behavior change for existing invocations that pass `--max-runtime` — that's the point (opt-out with `0`), but flagging it for the deploy checklist.

## Tests

Written first, watched fail (4 red): `TestDepthBudgetFloor` — default reservation, explicit flag, `0` opt-out, floor-exceeds-total clamp, `--skip-depth` bypass, and no-`--max-runtime` bypass, all network-free via the unsupported-source CSV; plus entrypoint forwarding of the new flag (POSIX-only in CI, hand-verified under bash locally: `--min-depth-runtime 45 --max-runtime 120` arrives as passed). Full suite: 59 passed, 6 skipped.

Touches `run_scraper_and_log_results` like #61/#62 — I'll rebase whichever of the three merges later.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)