### PR TITLE
Guard the image-phase --max-runtime budget with regression tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   pytest:

--- a/tests/test_download_runner.py
+++ b/tests/test_download_runner.py
@@ -1,12 +1,22 @@
-"""Subprocess tests for DownloadRunner.py.
+"""Tests for DownloadRunner.py.
 
-The pano CSV rows all use an unsupported source, so every pano is filtered out before any phase runs — the
-script exercises its full argument parsing, phase orchestration, and log.csv writing without any network I/O.
+Subprocess tests: the pano CSV rows all use an unsupported source, so every pano is filtered out before any
+phase runs — the script exercises its full argument parsing, phase orchestration, and log.csv writing without
+any network I/O.
+
+In-process tests: DownloadRunner is a script whose whole flow runs at import time, so importing it with a
+controlled argv — after replacing downloaders.download_pano, which it binds by `from downloaders import ...` —
+drives the real CSV → filter → phase call sites network-free and leaves the module in hand for calling
+download_panorama_images directly.
 """
 
+import importlib.util
 import os
 import subprocess
 import sys
+from datetime import datetime, timedelta
+
+import downloaders
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 RUNNER = os.path.join(REPO_ROOT, 'DownloadRunner.py')
@@ -102,3 +112,99 @@ def test_depth_covers_unlabeled_panos_that_the_image_phase_skips(tmp_path):
 def test_all_panos_widens_the_image_phase_only(tmp_path):
     stdout = run_selection_only(tmp_path, '--all-panos')
     assert 'Panos: 2 supported, 2 eligible for image download, 2 GSV panos eligible for depth' in stdout
+
+
+# --- Image-phase runtime budget -------------------------------------------------------------------------------
+#
+# Every subprocess test above filters its panos out before the image loop, so none of them would notice if the
+# --max-runtime budget stopped working. These tests feed SUPPORTED (gsv) panos through the real code with the
+# per-pano downloader stubbed, so the budget guard and its call-site plumbing are what's under test.
+
+GSV_PANO_IDS = ['gsvPanoIdAAAAAAAAAAAAA', 'gsvPanoIdBBBBBBBBBBBBB', 'gsvPanoIdCCCCCCCCCCCCC']
+GSV_CSV_ROWS = ''.join('%s,16384,8192,47.6,-122.3,180.0,0.0,gsv,True\n' % p for p in GSV_PANO_IDS)
+
+
+def recording_download_pano(calls):
+    """A download_pano stand-in that records each pano_id and reports success without touching the network."""
+    def fake_download_pano(storage_path, pano_info):
+        calls.append(pano_info['pano_id'])
+        return downloaders.DownloadResult.success
+    return fake_download_pano
+
+
+def load_runner(monkeypatch, tmp_path, csv_rows, *extra_args):
+    """Import DownloadRunner.py in-process and return (module, storage path, per-pano call log).
+
+    downloaders.download_pano is replaced with a recording stub BEFORE the import so DownloadRunner's
+    `from downloaders import download_pano` binds the stub; the import-time run then exercises the real
+    run_scraper_and_log_results call site with zero network I/O.
+    """
+    csv_path = tmp_path / 'panos.csv'
+    csv_path.write_text(CSV_HEADER + csv_rows)
+    storage = tmp_path / 'storage'
+    calls = []
+    monkeypatch.setattr(downloaders, 'download_pano', recording_download_pano(calls))
+    monkeypatch.setattr(sys, 'argv', ['DownloadRunner.py', 'sidewalk-test.invalid', str(storage),
+                                      '-c', str(csv_path), '--skip-depth', *extra_args])
+    monkeypatch.chdir(tmp_path)  # scrape.log is opened relative to the cwd
+    spec = importlib.util.spec_from_file_location('download_runner_under_test', RUNNER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module, storage, calls
+
+
+def gsv_pano_infos():
+    return [{'pano_id': p, 'source': 'gsv'} for p in GSV_PANO_IDS]
+
+
+def test_exhausted_budget_stops_download_panorama_images_before_the_first_pano(monkeypatch, tmp_path):
+    runner, _, _ = load_runner(monkeypatch, tmp_path, '')  # empty CSV: the import-time run is a no-op
+    image_storage = tmp_path / 'image_storage'
+    image_storage.mkdir()
+    calls = []
+    monkeypatch.setattr(runner, 'download_pano', recording_download_pano(calls))
+
+    result = runner.download_panorama_images(str(image_storage), gsv_pano_infos(),
+                                             run_start_time=datetime.now() - timedelta(minutes=10),
+                                             max_runtime_minutes=5.0)
+
+    assert calls == [], "an exhausted budget must break the loop before any download"
+    assert result == (0, 0, 0, 0, 0)
+
+
+def test_no_budget_lets_download_panorama_images_process_every_pano(monkeypatch, tmp_path):
+    """max_runtime_minutes=None means unlimited, however stale the start time is."""
+    runner, _, _ = load_runner(monkeypatch, tmp_path, '')
+    image_storage = tmp_path / 'image_storage'
+    image_storage.mkdir()
+    calls = []
+    monkeypatch.setattr(runner, 'download_pano', recording_download_pano(calls))
+
+    result = runner.download_panorama_images(str(image_storage), gsv_pano_infos(),
+                                             run_start_time=datetime.now() - timedelta(minutes=10),
+                                             max_runtime_minutes=None)
+
+    assert calls == GSV_PANO_IDS
+    assert result == (3, 0, 0, 0, 3)
+
+
+def test_max_runtime_flag_reaches_the_image_download_loop(monkeypatch, tmp_path, capsys):
+    """--max-runtime 0 must stop the image phase before any pano downloads.
+
+    This drives the real call site in run_scraper_and_log_results: a conflict resolution that drops
+    max_runtime_minutes there (e.g. passes None) downloads all three panos and fails here.
+    """
+    _, storage, calls = load_runner(monkeypatch, tmp_path, GSV_CSV_ROWS, '--max-runtime', '0')
+
+    assert calls == []
+    assert 'IMAGEDOWNLOAD: Max runtime' in capsys.readouterr().out
+    with open(storage / 'pano_id_log.csv') as f:
+        assert f.read().strip() == 'pano_id,downloaded', "no pano may be attempted or logged"
+
+
+def test_without_max_runtime_every_supported_pano_is_downloaded(monkeypatch, tmp_path):
+    _, storage, calls = load_runner(monkeypatch, tmp_path, GSV_CSV_ROWS)
+
+    assert calls == GSV_PANO_IDS
+    with open(storage / 'pano_id_log.csv') as f:
+        assert f.read().strip().splitlines() == ['pano_id,downloaded'] + ['%s,1' % p for p in GSV_PANO_IDS]


### PR DESCRIPTION
## Why

Three open PRs (#61, #62, #63) all rewrite the `download_panorama_images(...)` call site in `DownloadRunner.py`, and review of those PRs showed the runtime-budget behavior there is guarded by **nothing**: every existing test routes through CSVs whose rows are `source=unsupported`, so `download_panorama_images` always receives an empty list and the budget guard is never reached. Deleting the budget feature entirely leaves the whole suite green. Landing this before any of those three merge means a bad conflict resolution on that line fails CI instead of silently shipping.

## What

**Four behavioral tests** (in `tests/test_download_runner.py`), all network-free via a recording stub for `downloaders.download_pano`:

- Direct: an exhausted budget (start 10 min ago, `max_runtime_minutes=5`) stops `download_panorama_images` before the first pano; result is all zeros.
- Direct: `max_runtime_minutes=None` processes every pano regardless of how stale the start time is.
- End-to-end: `--max-runtime 0` with a supported-gsv CSV drives the real `run_scraper_and_log_results` call site — zero downloads, `IMAGEDOWNLOAD: Max runtime` printed, `pano_id_log.csv` header-only. This is the test that catches a call-site conflict resolution that drops `max_runtime_minutes` (verified by mutation: passing `None` at the call site fails exactly this test while the direct tests stay green).
- End-to-end: without the flag, all three panos download and are logged.

Mutation evidence: neutering the elapsed check (`if False:`) fails the two budget tests; reverting restores 4/4 green.

**Plus `workflow_dispatch:`** on `.github/workflows/tests.yml` — CI has not run on 4 of the 5 open PRs and there was previously no way to trigger it by hand.

## Test plan

- `python -m pytest -q` → 57 passed, 5 skipped (Windows; the 5 skips are the pre-existing `posix_only` entrypoint/file-mode tests, which run on Linux CI).
- Both mutations above verified to fail the new tests, then reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)