### PR TITLE
Extract build_parser()/main()/run() from DownloadRunner so importing it is inert (#52.1)

### DIFF
--- a/DownloadRunner.py
+++ b/DownloadRunner.py
@@ -34,45 +34,19 @@ def _reservation_minutes(value):
     return minutes
 
 
-parser = argparse.ArgumentParser()
-parser.add_argument('d', help='sidewalk_server_domain - FDQN of SidewalkWebpage server to fetch pano list from, i.e. sidewalk-columbus.cs.washington.edu')
-parser.add_argument('s', help='storage_path - location to store scraped panos')
-parser.add_argument('-c', nargs='?', default=None, help='csv_path - location of csv from which to read pano metadata')
-parser.add_argument('--all-panos', action='store_true', help='Download images for all panos that users visited, even if no labels were added on them. Does not affect depth, which always covers every pano.')
-parser.add_argument('--skip-depth', action='store_true', help='Skip downloading GSV depth maps (downloaded by default via the streetlevel library).')
-parser.add_argument('--max-runtime', type=float, default=None, metavar='MINUTES', help='Stop starting new downloads after this many minutes have elapsed.')
-parser.add_argument('--min-depth-runtime', type=_reservation_minutes, default=0.0, metavar='MINUTES', help='Reserve the last MINUTES of --max-runtime for the depth phase when the depth ledger shows unresolved work, so an image backlog cannot starve depth. This is a reservation carved out of the image phase\'s start budget, not a hard floor on depth wall time: the image phase stops STARTING new panos once its share is spent (a pano already in flight can overrun into the reserved slice), and depth still ends at --max-runtime, so it also gets any slack images leave. If the reservation meets or exceeds --max-runtime, NO images are downloaded that run. Default 0 (no reservation); the production crontab should pass 60. Ignored without --max-runtime or with --skip-depth.')
-parser.add_argument('--max-depth-requests', type=int, default=None, metavar='N', help='Stop the depth phase after this many depth metadata requests.')
-# Deprecated no-op, kept for one release so existing invocations don't crash argparse.
-parser.add_argument('--attempt-depth', action='store_true', help=argparse.SUPPRESS)
-args = parser.parse_args()
-
-sidewalk_server_fqdn = args.d
-storage_location = args.s
-pano_metadata_csv = args.c
-all_panos = args.all_panos
-skip_depth = args.skip_depth
-max_runtime_minutes = args.max_runtime
-min_depth_runtime = args.min_depth_runtime
-max_depth_requests = args.max_depth_requests
-
-if args.attempt_depth:
-    print("WARNING: --attempt-depth is deprecated and ignored; depth download is now on by default "
-          "(use --skip-depth to disable).")
-
-# min_depth_runtime > 0 implies the operator typed the flag (the default is 0), so tell them when the
-# combination they ran it in means it cannot do anything.
-if min_depth_runtime > 0 and (max_runtime_minutes is None or skip_depth):
-    print("WARNING: --min-depth-runtime has no effect %s; no time will be reserved for the depth phase."
-          % ("with --skip-depth" if skip_depth else "without --max-runtime"))
-
-print(sidewalk_server_fqdn)
-print(storage_location)
-print(pano_metadata_csv)
-print(all_panos)
-
-# exist_ok: concurrent city runs (or the operator pre-creating the dir) race on the exists check.
-os.makedirs(storage_location, exist_ok=True)
+def build_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('d', help='sidewalk_server_domain - FDQN of SidewalkWebpage server to fetch pano list from, i.e. sidewalk-columbus.cs.washington.edu')
+    parser.add_argument('s', help='storage_path - location to store scraped panos')
+    parser.add_argument('-c', nargs='?', default=None, help='csv_path - location of csv from which to read pano metadata')
+    parser.add_argument('--all-panos', action='store_true', help='Download images for all panos that users visited, even if no labels were added on them. Does not affect depth, which always covers every pano.')
+    parser.add_argument('--skip-depth', action='store_true', help='Skip downloading GSV depth maps (downloaded by default via the streetlevel library).')
+    parser.add_argument('--max-runtime', type=float, default=None, metavar='MINUTES', help='Stop starting new downloads after this many minutes have elapsed.')
+    parser.add_argument('--min-depth-runtime', type=_reservation_minutes, default=0.0, metavar='MINUTES', help='Reserve the last MINUTES of --max-runtime for the depth phase when the depth ledger shows unresolved work, so an image backlog cannot starve depth. This is a reservation carved out of the image phase\'s start budget, not a hard floor on depth wall time: the image phase stops STARTING new panos once its share is spent (a pano already in flight can overrun into the reserved slice), and depth still ends at --max-runtime, so it also gets any slack images leave. If the reservation meets or exceeds --max-runtime, NO images are downloaded that run. Default 0 (no reservation); the production crontab should pass 60. Ignored without --max-runtime or with --skip-depth.')
+    parser.add_argument('--max-depth-requests', type=int, default=None, metavar='N', help='Stop the depth phase after this many depth metadata requests.')
+    # Deprecated no-op, kept for one release so existing invocations don't crash argparse.
+    parser.add_argument('--attempt-depth', action='store_true', help=argparse.SUPPRESS)
+    return parser
 
 
 def configure_logging(log_path):
@@ -96,20 +70,6 @@ def configure_logging(log_path):
     if fallback_error is not None:
         logging.warning("Could not open %s (%s); logging to stderr for this run", log_path, fallback_error)
     logging.getLogger('urllib3').setLevel(logging.WARNING)
-
-
-# scrape.log lives on the pano store next to log.csv, NOT the CWD: in Docker the CWD is /app inside the
-# container, so a relative path would discard the log - and every per-pano failure detail - when the container
-# exits (#49). Configured once here at startup so every part of the run logs to the same file - including a
-# crash in the pano-list fetch below, which happens before any phase's own code gets a chance to run.
-configure_logging(os.path.join(storage_location, 'scrape.log'))
-
-# docker stop sends SIGTERM, which CPython by default dies from without running finally blocks - taking the
-# log.csv evidence row with it (#49). Translate it into a SystemExit carrying the conventional 128+15 code, so
-# cleanup runs and the exit still reads as a signal death.
-signal.signal(signal.SIGTERM, lambda *_: sys.exit(143))
-
-print("Starting run with pano list fetched from %s and destination path %s" % (sidewalk_server_fqdn, storage_location))
 
 
 def progress_check(csv_pano_log_path):
@@ -136,9 +96,9 @@ def fetch_pano_ids_csv(metadata_csv_path):
     return df_meta
 
 
-def fetch_pano_ids_from_webserver():
+def fetch_pano_ids_from_webserver(sidewalk_server_fqdn):
     """
-    Fetch pano metadata from /adminapi/panos.
+    Fetch pano metadata from /adminapi/panos on sidewalk_server_fqdn.
 
     Each entry is a dict with: pano_id, width, height, lat, lng, camera_heading, camera_pitch, source, has_labels.
 
@@ -309,8 +269,8 @@ def download_panorama_images(storage_path, pano_infos, run_start_monotonic=None,
 LOG_CSV_FIELD_COUNT = 18
 
 
-def write_log_csv_row(fields):
-    """Append one run's row to log.csv, blank-padded to the full 18 columns.
+def write_log_csv_row(storage_location, fields):
+    """Append one run's row to <storage_location>/log.csv, blank-padded to the full 18 columns.
 
     Blank means the phase never finished - visibly missing data, not a fake zero. If the append itself fails
     (the classic cause: the sshfs store went away mid-run), the joined row is printed to stderr before the
@@ -328,8 +288,8 @@ def write_log_csv_row(fields):
         raise
 
 
-def run_scraper_and_log_results(image_pano_infos, depth_pano_infos, skip_depth, max_runtime_minutes=None,
-                                max_depth_requests=None, min_depth_runtime=0.0):
+def run_scraper_and_log_results(storage_location, image_pano_infos, depth_pano_infos, skip_depth,
+                                max_runtime_minutes=None, max_depth_requests=None, min_depth_runtime=0.0):
     """Run the image and depth phases and append this run's row to log.csv.
 
     Fields are accumulated as each phase completes and the row is written once, in a finally, padded to the
@@ -337,6 +297,7 @@ def run_scraper_and_log_results(image_pano_infos, depth_pano_infos, skip_depth, 
     completed phase's counts (a failure in the depth phase must not discard what the image phase downloaded),
     while the phases that never finished stay visibly blank rather than turning into fake zeros (#49).
 
+    @param storage_location Root of the pano store (log.csv and the ledgers live here).
     @param image_pano_infos Panos eligible for image download (narrowed by --all-panos).
     @param depth_pano_infos Every supported pano; the depth phase filters this to source == 'gsv' itself.
     @param min_depth_runtime Minutes of max_runtime_minutes reserved for the depth phase (see the flag's help).
@@ -411,43 +372,101 @@ def run_scraper_and_log_results(image_pano_infos, depth_pano_infos, skip_depth, 
 
         fields.append(int(round((depth_end_time - start_time).total_seconds() / 60.0)))
     finally:
-        write_log_csv_row(fields)
+        write_log_csv_row(storage_location, fields)
 
 
-# Access Project Sidewalk API to get Pano IDs for city
-print("Fetching pano-ids")
+def run(sidewalk_server_fqdn, storage_location, pano_metadata_csv=None, all_panos=False, skip_depth=False,
+        max_runtime_minutes=None, min_depth_runtime=0.0, max_depth_requests=None):
+    """Fetch the pano list, narrow it, and run the scrape - the whole job, minus process-level setup.
 
-try:
-    if pano_metadata_csv is not None:
-        pano_infos = fetch_pano_ids_csv(pano_metadata_csv)
-    else:
-        pano_infos = fetch_pano_ids_from_webserver()
-    pano_infos = filter_supported_sources(pano_infos)
-    image_pano_infos = select_image_panos(pano_infos, all_panos)
-except BaseException:
-    # A crash before the scrape starts - a webserver outage being the single most likely nightly failure - must
-    # still leave both kinds of evidence (#49): the traceback in scrape.log, and a blank-padded log.csv row
-    # whose real timestamp shows a run started and produced nothing.
-    logging.exception("Run crashed before the scrape started")
-    write_log_csv_row([str(datetime.now())])
-    raise
+    main() owns argv parsing, directory creation, logging, and signal handling; this seam takes plain
+    arguments (defaults mirror the flags') so tests can drive the real fetch -> filter -> phase orchestration
+    in-process (#52.1).
+    """
+    # Access Project Sidewalk API to get Pano IDs for city
+    print("Fetching pano-ids")
 
-# Uncomment this to test on a smaller subset of the pano_info.
-# import random
-# n = 3
-# if len(pano_infos) > n:
-#     pano_infos = random.sample(pano_infos, n)
+    try:
+        if pano_metadata_csv is not None:
+            pano_infos = fetch_pano_ids_csv(pano_metadata_csv)
+        else:
+            pano_infos = fetch_pano_ids_from_webserver(sidewalk_server_fqdn)
+        pano_infos = filter_supported_sources(pano_infos)
+        image_pano_infos = select_image_panos(pano_infos, all_panos)
+    except BaseException:
+        # A crash before the scrape starts - a webserver outage being the single most likely nightly failure -
+        # must still leave both kinds of evidence (#49): the traceback in scrape.log, and a blank-padded
+        # log.csv row whose real timestamp shows a run started and produced nothing.
+        logging.exception("Run crashed before the scrape started")
+        write_log_csv_row(storage_location, [str(datetime.now())])
+        raise
 
-print("Panos: %d supported, %d eligible for image download, %d GSV panos eligible for depth"
-      % (len(pano_infos), len(image_pano_infos), sum(1 for p in pano_infos if p.get('source') == 'gsv')))
+    # Uncomment this to test on a smaller subset of the pano_info.
+    # import random
+    # n = 3
+    # if len(pano_infos) > n:
+    #     pano_infos = random.sample(pano_infos, n)
 
-# Use pano_id list and associated info to gather panos from respective APIs
-print("Fetching Panoramas")
-try:
-    run_scraper_and_log_results(image_pano_infos, pano_infos, skip_depth, max_runtime_minutes=max_runtime_minutes,
-                                max_depth_requests=max_depth_requests, min_depth_runtime=min_depth_runtime)
-except BaseException:
-    # run_scraper_and_log_results's own finally has already written the evidence row; this puts the traceback -
-    # otherwise stderr-only, the exact channel that dies with the container - into scrape.log too (#49).
-    logging.exception("Run failed")
-    raise
+    print("Panos: %d supported, %d eligible for image download, %d GSV panos eligible for depth"
+          % (len(pano_infos), len(image_pano_infos), sum(1 for p in pano_infos if p.get('source') == 'gsv')))
+
+    # Use pano_id list and associated info to gather panos from respective APIs
+    print("Fetching Panoramas")
+    try:
+        run_scraper_and_log_results(storage_location, image_pano_infos, pano_infos, skip_depth,
+                                    max_runtime_minutes=max_runtime_minutes,
+                                    max_depth_requests=max_depth_requests, min_depth_runtime=min_depth_runtime)
+    except BaseException:
+        # run_scraper_and_log_results's own finally has already written the evidence row; this puts the
+        # traceback - otherwise stderr-only, the exact channel that dies with the container - into scrape.log
+        # too (#49).
+        logging.exception("Run failed")
+        raise
+
+
+def main(argv=None):
+    """Process-level setup, then run(): everything a `python3 DownloadRunner.py ...` invocation does.
+
+    Exceptions propagate (the interpreter prints the traceback and exits 1) and argparse errors exit 2,
+    exactly as the pre-#52 module-scope script behaved.
+    """
+    args = build_parser().parse_args(argv)
+
+    if args.attempt_depth:
+        print("WARNING: --attempt-depth is deprecated and ignored; depth download is now on by default "
+              "(use --skip-depth to disable).")
+
+    # min_depth_runtime > 0 implies the operator typed the flag (the default is 0), so tell them when the
+    # combination they ran it in means it cannot do anything.
+    if args.min_depth_runtime > 0 and (args.max_runtime is None or args.skip_depth):
+        print("WARNING: --min-depth-runtime has no effect %s; no time will be reserved for the depth phase."
+              % ("with --skip-depth" if args.skip_depth else "without --max-runtime"))
+
+    print(args.d)
+    print(args.s)
+    print(args.c)
+    print(args.all_panos)
+
+    # exist_ok: concurrent city runs (or the operator pre-creating the dir) race on the exists check.
+    os.makedirs(args.s, exist_ok=True)
+
+    # scrape.log lives on the pano store next to log.csv, NOT the CWD: in Docker the CWD is /app inside the
+    # container, so a relative path would discard the log - and every per-pano failure detail - when the
+    # container exits (#49). Configured once here at startup so every part of the run logs to the same file -
+    # including a crash in the pano-list fetch, which happens before any phase's own code gets a chance to run.
+    configure_logging(os.path.join(args.s, 'scrape.log'))
+
+    # docker stop sends SIGTERM, which CPython by default dies from without running finally blocks - taking the
+    # log.csv evidence row with it (#49). Translate it into a SystemExit carrying the conventional 128+15 code,
+    # so cleanup runs and the exit still reads as a signal death.
+    signal.signal(signal.SIGTERM, lambda *_: sys.exit(143))
+
+    print("Starting run with pano list fetched from %s and destination path %s" % (args.d, args.s))
+
+    run(sidewalk_server_fqdn=args.d, storage_location=args.s, pano_metadata_csv=args.c,
+        all_panos=args.all_panos, skip_depth=args.skip_depth, max_runtime_minutes=args.max_runtime,
+        min_depth_runtime=args.min_depth_runtime, max_depth_requests=args.max_depth_requests)
+
+
+if __name__ == '__main__':
+    main()

--- a/DownloadRunner.py
+++ b/DownloadRunner.py
@@ -442,11 +442,6 @@ def main(argv=None):
         print("WARNING: --min-depth-runtime has no effect %s; no time will be reserved for the depth phase."
               % ("with --skip-depth" if args.skip_depth else "without --max-runtime"))
 
-    print(args.d)
-    print(args.s)
-    print(args.c)
-    print(args.all_panos)
-
     # exist_ok: concurrent city runs (or the operator pre-creating the dir) race on the exists check.
     os.makedirs(args.s, exist_ok=True)
 

--- a/tests/test_download_runner.py
+++ b/tests/test_download_runner.py
@@ -570,6 +570,72 @@ def test_sigterm_is_translated_to_systemexit_so_the_evidence_row_still_lands(dow
     assert excinfo.value.code == 143  # the conventional 128+15, what a signal death reports anyway
 
 
+# ---------------------------------------------------------------------------------------------------------
+# The #52 seams: importing the module is inert; argv handling lives in main(); the fetch-and-scrape
+# orchestration lives in run(), callable with plain arguments.
+# ---------------------------------------------------------------------------------------------------------
+
+def _fresh_import(monkeypatch, argv):
+    """Import DownloadRunner from scratch under a controlled argv and return the module."""
+    monkeypatch.setattr(sys, 'argv', argv)
+    monkeypatch.delitem(sys.modules, 'DownloadRunner', raising=False)
+    import DownloadRunner as module
+    return module
+
+
+def test_import_is_side_effect_free(tmp_path, monkeypatch):
+    """Importing DownloadRunner must not read argv, touch the filesystem, or mutate process-wide state -
+    all of that belongs to main() (#52.1). On the pre-#52 script this fails at the import itself: argparse
+    runs at module scope, sees pytest's argv, and exits 2."""
+    monkeypatch.chdir(tmp_path)
+    root = logging.getLogger()
+    handlers_before = list(root.handlers)
+    urllib3_before = logging.getLogger('urllib3').level
+    sigterm_before = signal.getsignal(signal.SIGTERM)
+
+    _fresh_import(monkeypatch, ['pytest'])
+
+    assert list(root.handlers) == handlers_before, "import must not add root-logger handlers"
+    assert logging.getLogger('urllib3').level == urllib3_before
+    assert signal.getsignal(signal.SIGTERM) is sigterm_before, "import must not install signal handlers"
+    assert list(tmp_path.iterdir()) == [], "import must not create directories or log files"
+
+
+def test_main_with_bad_argv_exits_2(tmp_path, monkeypatch):
+    """argparse's error contract survives the main() extraction, exercised in-process."""
+    monkeypatch.chdir(tmp_path)
+    module = _fresh_import(monkeypatch, ['pytest'])
+
+    for argv in ([], ['host-only']):
+        with pytest.raises(SystemExit) as excinfo:
+            module.main(argv)
+        assert excinfo.value.code == 2
+
+
+def test_run_writes_evidence_row_when_fetch_raises(tmp_path, monkeypatch):
+    """The #49 evidence path at the new run() seam: a pano-list fetch crash must leave a blank-padded
+    18-field log.csv row whose real timestamp shows a run started and produced nothing. In-process and
+    deterministic - unlike the subprocess variant, which relies on .invalid DNS failing through the whole
+    retry stack."""
+    monkeypatch.chdir(tmp_path)
+    module = _fresh_import(monkeypatch, ['pytest'])
+    storage = tmp_path / 'storage'
+    storage.mkdir()
+
+    def fetch_boom(sidewalk_server_fqdn):
+        raise RuntimeError('webserver down')
+
+    monkeypatch.setattr(module, 'fetch_pano_ids_from_webserver', fetch_boom)
+
+    with pytest.raises(RuntimeError, match='webserver down'):
+        module.run('sidewalk-test.invalid', str(storage))
+
+    fields = last_log_fields(storage)
+    assert len(fields) == 18
+    assert fields[0] != ''  # a real timestamp: evidence the run started
+    assert fields[1:] == [''] * 17  # no phase ran - all blank, not fake zeros
+
+
 # Runs DownloadRunner.py (via runpy — argparse at module scope rules out an import) with Session.get stubbed
 # to capture the HTTP config the pano-list fetch actually uses, reported as JSON on the last stdout line.
 # No network I/O: the stub raises SystemExit before anything touches a socket.

--- a/tests/test_download_runner.py
+++ b/tests/test_download_runner.py
@@ -12,7 +12,6 @@ functions directly with plain arguments.
 """
 
 import ast
-import json
 import logging
 import logging.handlers
 import os
@@ -20,6 +19,8 @@ import signal
 import subprocess
 import sys
 import time
+
+import requests
 
 import downloaders
 import DownloadRunner
@@ -626,46 +627,9 @@ def test_run_writes_evidence_row_when_fetch_raises(tmp_path, monkeypatch):
     assert fields[1:] == [''] * 17  # no phase ran - all blank, not fake zeros
 
 
-# Runs DownloadRunner.py (via runpy — argparse at module scope rules out an import) with Session.get stubbed
-# to capture the HTTP config the pano-list fetch actually uses, reported as JSON on the last stdout line.
-# No network I/O: the stub raises SystemExit before anything touches a socket.
-FETCH_CONFIG_PROBE = '''\
-import json
-import os
-import runpy
-import sys
-
-import requests
-
-runner, storage = sys.argv[1], sys.argv[2]
-# Running a script directly puts its directory on sys.path; runpy does not, so add it for `import downloaders`.
-sys.path.insert(0, os.path.dirname(os.path.abspath(runner)))
-captured = {}
-
-
-def capturing_get(self, url, **kwargs):
-    retries = {}
-    for scheme in ('https', 'http'):
-        retry = self.get_adapter(scheme + '://example.com').max_retries
-        retries[scheme] = {'total': retry.total, 'connect': retry.connect, 'read': retry.read}
-    timeout = kwargs.get('timeout')
-    captured.update(url=url, timeout=list(timeout) if isinstance(timeout, tuple) else timeout,
-                    trust_env=self.trust_env, retries=retries)
-    raise SystemExit(0)
-
-
-requests.Session.get = capturing_get
-sys.argv = ['DownloadRunner.py', 'sidewalk-test.invalid', storage]
-try:
-    runpy.run_path(runner, run_name='__main__')
-except SystemExit:
-    pass
-print(json.dumps(captured))
-'''
-
-
-def test_pano_list_fetch_session_configuration(tmp_path):
-    """Pin the pano-list fetch's HTTP config (#51 review).
+def test_pano_list_fetch_session_configuration(monkeypatch):
+    """Pin the pano-list fetch's HTTP config (#51 review), in-process at the #52.1 seam - the fqdn is now a
+    parameter, so no subprocess/runpy probe is needed.
 
     - timeout (30, 600): the read timeout applies per socket op INCLUDING the wait for the status line, and
       /adminapi/panos plausibly buffers the whole JSON server-side before its first byte on the largest
@@ -676,16 +640,26 @@ def test_pano_list_fetch_session_configuration(tmp_path):
       overrides) on a fleet cron whose environment we don't control.
     - The retry adapter is mounted on http:// as well, so a redirect hop can't silently lose the policy.
     """
-    probe = tmp_path / 'fetch_config_probe.py'
-    probe.write_text(FETCH_CONFIG_PROBE)
-    result = subprocess.run(
-        [sys.executable, str(probe), RUNNER, str(tmp_path / 'storage')],
-        cwd=str(tmp_path), capture_output=True, text=True, timeout=120)
-    assert result.returncode == 0, result.stderr
-    captured = json.loads(result.stdout.strip().splitlines()[-1])
+    captured = {}
+
+    class _ProbeStop(Exception):
+        """Raised by the stub before anything touches a socket."""
+
+    def capturing_get(self, url, **kwargs):
+        retries = {}
+        for scheme in ('https', 'http'):
+            retry = self.get_adapter(scheme + '://example.com').max_retries
+            retries[scheme] = {'total': retry.total, 'connect': retry.connect, 'read': retry.read}
+        captured.update(url=url, timeout=kwargs.get('timeout'), trust_env=self.trust_env, retries=retries)
+        raise _ProbeStop()
+
+    monkeypatch.setattr(requests.Session, 'get', capturing_get)
+
+    with pytest.raises(_ProbeStop):
+        DownloadRunner.fetch_pano_ids_from_webserver('sidewalk-test.invalid')
 
     assert captured['url'] == 'https://sidewalk-test.invalid/adminapi/panos'
-    assert captured['timeout'] == [30, 600]
+    assert captured['timeout'] == (30, 600)
     assert captured['trust_env'] is False
     for scheme in ('https', 'http'):
         retry = captured['retries'][scheme]

--- a/tests/test_download_runner.py
+++ b/tests/test_download_runner.py
@@ -1,18 +1,17 @@
-"""Tests for DownloadRunner.py: subprocess runs of the whole script, plus in-process calls via a fixture.
+"""Tests for DownloadRunner.py: subprocess runs of the whole script, plus in-process calls.
 
 Subprocess tests: the unsupported-source pano CSV filters every pano out before any phase runs, so those runs
 exercise argument parsing, phase orchestration, and log.csv writing with no network I/O. The gsv-source CSVs
 feed the budget tests: those runs stub the per-pano download (via a driver script for subprocess runs) and cap
 the depth phase at 0 requests, so they count what the image phase actually downloads — still no network I/O.
 
-In-process tests: DownloadRunner is a script whose whole flow runs at import time, so importing it with a
-controlled argv — after replacing downloaders.download_pano, which it binds by `from downloaders import ...` —
-drives the real CSV → filter → phase call sites network-free and leaves the module in hand for calling
-download_panorama_images directly.
+In-process tests: since #52.1 the module imports inertly (argv, filesystem, logging, and signal setup all live
+in main()), so tests import it normally and either call main() with a controlled argv — after replacing
+DownloadRunner.download_pano, bound at its import by `from downloaders import ...` — or call the phase
+functions directly with plain arguments.
 """
 
 import ast
-import importlib.util
 import json
 import logging
 import logging.handlers
@@ -23,6 +22,7 @@ import sys
 import time
 
 import downloaders
+import DownloadRunner
 
 import pytest
 
@@ -243,7 +243,9 @@ def _fake_download_pano(storage_path, pano_info):
 
 downloaders.download_pano = _fake_download_pano
 sys.argv = ['DownloadRunner.py'] + sys.argv[1:]
-runpy.run_path(%(runner)r)
+# run_name='__main__' so the script's `if __name__ == '__main__'` guard fires - this driver exists to
+# exercise true script-style execution.
+runpy.run_path(%(runner)r, run_name='__main__')
 ''' % {'repo_root': REPO_ROOT, 'runner': RUNNER}
 
 
@@ -363,9 +365,9 @@ def test_all_panos_widens_the_image_phase_only(tmp_path):
 
 @pytest.fixture(autouse=True)
 def _isolate_process_state():
-    """Importing DownloadRunner configures process-wide state (root logger handlers, urllib3's level, the
-    SIGTERM handler); snapshot and restore it around every test so the in-process imports below can't leak
-    into each other or into the rest of the suite."""
+    """Calling DownloadRunner.main() (or configure_logging directly) mutates process-wide state - root logger
+    handlers, urllib3's level, the SIGTERM handler; snapshot and restore it around every test so the
+    in-process calls below can't leak into each other or into the rest of the suite."""
     root = logging.getLogger()
     prior_handlers = list(root.handlers)
     prior_level = root.level
@@ -399,25 +401,22 @@ def recording_download_pano(calls):
     return fake_download_pano
 
 
-def load_runner(monkeypatch, tmp_path, csv_rows, *extra_args):
-    """Import DownloadRunner.py in-process and return (module, storage path, per-pano call log).
+def call_main(monkeypatch, tmp_path, csv_rows, *extra_args):
+    """Run DownloadRunner.main() in-process and return (storage path, per-pano call log).
 
-    downloaders.download_pano is replaced with a recording stub BEFORE the import so DownloadRunner's
-    `from downloaders import download_pano` binds the stub; the import-time run then exercises the real
-    run_scraper_and_log_results call site with zero network I/O.
+    DownloadRunner.download_pano - the name its image loop calls, bound at its import by
+    `from downloaders import ...` - is replaced with a recording stub first, so the real
+    fetch -> filter -> run_scraper_and_log_results orchestration runs with zero network I/O.
     """
     csv_path = tmp_path / 'panos.csv'
     csv_path.write_text(CSV_HEADER + csv_rows)
     storage = tmp_path / 'storage'
     calls = []
-    monkeypatch.setattr(downloaders, 'download_pano', recording_download_pano(calls))
-    monkeypatch.setattr(sys, 'argv', ['DownloadRunner.py', 'sidewalk-test.invalid', str(storage),
-                                      '-c', str(csv_path), '--skip-depth', *extra_args])
+    monkeypatch.setattr(DownloadRunner, 'download_pano', recording_download_pano(calls))
     monkeypatch.chdir(tmp_path)  # keep any stray relative paths inside this test's tmp dir
-    spec = importlib.util.spec_from_file_location('download_runner_under_test', RUNNER)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module, storage, calls
+    DownloadRunner.main(['sidewalk-test.invalid', str(storage), '-c', str(csv_path), '--skip-depth',
+                         *extra_args])
+    return storage, calls
 
 
 def gsv_pano_infos():
@@ -425,15 +424,14 @@ def gsv_pano_infos():
 
 
 def test_exhausted_budget_stops_download_panorama_images_before_the_first_pano(monkeypatch, tmp_path):
-    runner, _, _ = load_runner(monkeypatch, tmp_path, '')  # empty CSV: the import-time run is a no-op
     image_storage = tmp_path / 'image_storage'
     image_storage.mkdir()
     calls = []
-    monkeypatch.setattr(runner, 'download_pano', recording_download_pano(calls))
+    monkeypatch.setattr(DownloadRunner, 'download_pano', recording_download_pano(calls))
 
-    result = runner.download_panorama_images(str(image_storage), gsv_pano_infos(),
-                                             run_start_monotonic=time.monotonic() - 600,
-                                             max_runtime_minutes=5.0)
+    result = DownloadRunner.download_panorama_images(str(image_storage), gsv_pano_infos(),
+                                                     run_start_monotonic=time.monotonic() - 600,
+                                                     max_runtime_minutes=5.0)
 
     assert calls == [], "an exhausted budget must break the loop before any download"
     assert result == (0, 0, 0, 0, 0)
@@ -441,15 +439,14 @@ def test_exhausted_budget_stops_download_panorama_images_before_the_first_pano(m
 
 def test_no_budget_lets_download_panorama_images_process_every_pano(monkeypatch, tmp_path):
     """max_runtime_minutes=None means unlimited, however stale the start time is."""
-    runner, _, _ = load_runner(monkeypatch, tmp_path, '')
     image_storage = tmp_path / 'image_storage'
     image_storage.mkdir()
     calls = []
-    monkeypatch.setattr(runner, 'download_pano', recording_download_pano(calls))
+    monkeypatch.setattr(DownloadRunner, 'download_pano', recording_download_pano(calls))
 
-    result = runner.download_panorama_images(str(image_storage), gsv_pano_infos(),
-                                             run_start_monotonic=time.monotonic() - 600,
-                                             max_runtime_minutes=None)
+    result = DownloadRunner.download_panorama_images(str(image_storage), gsv_pano_infos(),
+                                                     run_start_monotonic=time.monotonic() - 600,
+                                                     max_runtime_minutes=None)
 
     assert calls == GSV_PANO_IDS
     assert result == (3, 0, 0, 0, 3)
@@ -461,7 +458,7 @@ def test_max_runtime_flag_reaches_the_image_download_loop(monkeypatch, tmp_path,
     This drives the real call site in run_scraper_and_log_results: a conflict resolution that drops
     max_runtime_minutes there (e.g. passes None) downloads all three panos and fails here.
     """
-    _, storage, calls = load_runner(monkeypatch, tmp_path, GSV_CSV_ROWS, '--max-runtime', '0')
+    storage, calls = call_main(monkeypatch, tmp_path, GSV_CSV_ROWS, '--max-runtime', '0')
 
     assert calls == []
     assert 'IMAGEDOWNLOAD: Max runtime' in capsys.readouterr().out
@@ -470,7 +467,7 @@ def test_max_runtime_flag_reaches_the_image_download_loop(monkeypatch, tmp_path,
 
 
 def test_without_max_runtime_every_supported_pano_is_downloaded(monkeypatch, tmp_path):
-    _, storage, calls = load_runner(monkeypatch, tmp_path, GSV_CSV_ROWS)
+    storage, calls = call_main(monkeypatch, tmp_path, GSV_CSV_ROWS)
 
     assert calls == GSV_PANO_IDS
     with open(storage / 'pano_id_log.csv') as f:
@@ -491,27 +488,12 @@ def test_broken_scrape_log_falls_back_to_stderr_and_the_run_survives(tmp_path):
 
 
 # ---------------------------------------------------------------------------------------------------------
-# In-process tests. DownloadRunner is a script - argparse and the whole run execute at import - so the
-# fixture points argv at the all-filtered pano CSV, making the import itself a harmless network-free
-# mini-run, then hands the module over for direct calls with monkeypatched collaborators.
+# In-process tests. Since #52.1 the module imports inertly, so these call the extracted functions directly
+# with plain arguments; _isolate_process_state (autouse) undoes the process-wide state that calling main()
+# or configure_logging() configures.
 # ---------------------------------------------------------------------------------------------------------
 
-@pytest.fixture
-def download_runner(tmp_path, monkeypatch, _isolate_process_state):
-    """Import DownloadRunner in-process; _isolate_process_state undoes the process-wide state the import
-    configures (root logger, urllib3 level, SIGTERM) after the test."""
-    monkeypatch.setattr(sys, 'argv',
-                        ['DownloadRunner.py', 'sidewalk-test.invalid', str(tmp_path / 'import_storage'),
-                         '-c', write_pano_csv(tmp_path), '--skip-depth'])
-    sys.modules.pop('DownloadRunner', None)
-    try:
-        import DownloadRunner
-        yield DownloadRunner
-    finally:
-        sys.modules.pop('DownloadRunner', None)
-
-
-def test_depth_crash_keeps_the_image_phases_real_counts(download_runner, tmp_path, monkeypatch):
+def test_depth_crash_keeps_the_image_phases_real_counts(tmp_path, monkeypatch):
     """misaugstad's review concern on #49: a depth-phase crash must not discard what the image phase downloaded.
 
     The subprocess crash tests can't cover this - their filtered-out panos make every completed count 0, which
@@ -519,16 +501,15 @@ def test_depth_crash_keeps_the_image_phases_real_counts(download_runner, tmp_pat
     """
     storage = tmp_path / 'crash_storage'
     storage.mkdir()
-    monkeypatch.setattr(download_runner, 'storage_location', str(storage))
-    monkeypatch.setattr(download_runner, 'download_panorama_images', lambda *a, **k: (3, 1, 2, 4, 10))
+    monkeypatch.setattr(DownloadRunner, 'download_panorama_images', lambda *a, **k: (3, 1, 2, 4, 10))
 
     def depth_boom(*args, **kwargs):
         raise RuntimeError('depth phase exploded')
-    monkeypatch.setattr(download_runner.gsv, 'download_depth_maps', depth_boom)
+    monkeypatch.setattr(DownloadRunner.gsv, 'download_depth_maps', depth_boom)
 
     panos = [{'pano_id': 'testPanoIdAAAAAAAAAAAA', 'source': 'gsv'}]
     with pytest.raises(RuntimeError, match='depth phase exploded'):
-        download_runner.run_scraper_and_log_results(panos, panos, skip_depth=False)
+        DownloadRunner.run_scraper_and_log_results(str(storage), panos, panos, skip_depth=False)
 
     fields = last_log_fields(storage)
     assert len(fields) == 18
@@ -537,22 +518,23 @@ def test_depth_crash_keeps_the_image_phases_real_counts(download_runner, tmp_pat
     assert fields[12:] == [''] * 6  # depth and total never finished - blank, not fabricated
 
 
-def test_an_overwide_log_row_errors_instead_of_silently_widening(download_runner):
+def test_an_overwide_log_row_errors_instead_of_silently_widening(tmp_path):
     """Blank-padding computes 18 - len(fields); a future 19th field must fail loudly, not no-op the padding."""
     with pytest.raises(AssertionError):
-        download_runner.write_log_csv_row(['x'] * 19)
+        DownloadRunner.write_log_csv_row(str(tmp_path), ['x'] * 19)
 
 
-def test_log_row_write_failure_dumps_the_row_to_stderr(download_runner, tmp_path, monkeypatch, capsys):
+def test_log_row_write_failure_dumps_the_row_to_stderr(tmp_path, capsys):
     """If appending to log.csv itself fails (unmounted store), the counts must survive somewhere cron can mail."""
-    monkeypatch.setattr(download_runner, 'storage_location', str(tmp_path / 'gone' / 'unmounted'))
     with pytest.raises(OSError):
-        download_runner.write_log_csv_row(['2026-08-06 01:00:00', 1, 2])
+        DownloadRunner.write_log_csv_row(str(tmp_path / 'gone' / 'unmounted'), ['2026-08-06 01:00:00', 1, 2])
     assert '2026-08-06 01:00:00,1,2' in capsys.readouterr().err
 
 
-def test_urllib3_is_quieted_and_scrape_log_rotates(download_runner):
+def test_urllib3_is_quieted_and_scrape_log_rotates(tmp_path):
     """DEBUG-level urllib3 chatter means one synchronous sshfs write per HTTP request and unbounded growth."""
+    DownloadRunner.configure_logging(str(tmp_path / 'scrape.log'))
+
     assert logging.getLogger('urllib3').getEffectiveLevel() == logging.WARNING
     rotating = [h for h in logging.getLogger().handlers
                 if isinstance(h, logging.handlers.RotatingFileHandler)]
@@ -561,10 +543,18 @@ def test_urllib3_is_quieted_and_scrape_log_rotates(download_runner):
     assert rotating[0].backupCount == 3
 
 
-def test_sigterm_is_translated_to_systemexit_so_the_evidence_row_still_lands(download_runner):
-    """docker stop sends SIGTERM; CPython's default dies without running finally blocks, losing the row (#49)."""
+def test_sigterm_is_translated_to_systemexit_so_the_evidence_row_still_lands(tmp_path, monkeypatch):
+    """docker stop sends SIGTERM; CPython's default dies without running finally blocks, losing the row (#49).
+
+    The handler is installed by main() - not by importing the module (test_import_is_side_effect_free pins
+    the other side of that seam) - so run a harmless all-filtered mini-scrape to get it installed.
+    """
+    monkeypatch.chdir(tmp_path)
+    DownloadRunner.main(['sidewalk-test.invalid', str(tmp_path / 'storage'), '-c', write_pano_csv(tmp_path),
+                         '--skip-depth'])
+
     handler = signal.getsignal(signal.SIGTERM)
-    assert callable(handler), "DownloadRunner must install a SIGTERM handler"
+    assert callable(handler), "DownloadRunner.main() must install a SIGTERM handler"
     with pytest.raises(SystemExit) as excinfo:
         handler(signal.SIGTERM, None)
     assert excinfo.value.code == 143  # the conventional 128+15, what a signal death reports anyway


### PR DESCRIPTION
Implements item 1 of #52 for `DownloadRunner.py` — the structural precondition for testing the image path the way the depth phase already is tested, and the prerequisite the ledger/retry PRs in this batch build on.

## What changes

`DownloadRunner.py` previously executed everything at module scope: `parse_args()` read pytest''s argv at import (`SystemExit(2)`), `os.makedirs` and `configure_logging` wrote to disk, and a SIGTERM handler landed process-wide — importing the module *was* running it. Now:

* **`build_parser()`** — the argparse config, returnable and introspectable.
* **`run(sidewalk_server_fqdn, storage_location, pano_metadata_csv=None, ...)`** — the fetch → filter → scrape orchestration with plain parameters, including the #49 evidence-row handling. The module globals are gone: `fetch_pano_ids_from_webserver(fqdn)`, `write_log_csv_row(storage_location, fields)`, and `run_scraper_and_log_results(storage_location, ...)` now take what they used to read ambiently — which also dissolves the parameter-shadows-global confusion the issue calls out.
* **`main(argv=None)`** — process-level setup in the original statement order (warnings, makedirs, logging, SIGTERM translation), then `run()`. Behind an `if __name__ == ''__main__''` guard (the `migrate_depth_artifacts.py` model).

**The CLI contract is byte-for-byte preserved**: same argv handling, same exit codes (2 argparse, 143 SIGTERM, 1 traceback, 0 success), same stdout ordering — statements moved, never reordered. The Docker entrypoint and its tests are untouched. One deliberate behavior change rides in its own labeled commit: the four bare debug prints (`d`/`s`/`-c`/`--all-panos` values with no labels, #52 item 4) are dropped from startup.

**CropRunner deliberately deferred** to the first cropper PR (#47/#48/#32): its extraction must arrive with its first-ever tests, and its import-time CWD-relative `crop.log` (the same disease #49 fixed here) deserves that discussion, not a ride-along.

## Test evidence (test-first)

Commit 1 adds three tests that fail on the pre-#52 script — all with `SystemExit(2)` raised by argparse *at import*, which is the defect itself:

* `test_import_is_side_effect_free` — importing must not read argv, create directories, open `scrape.log`, add root-logger handlers, or install the SIGTERM handler;
* `test_main_with_bad_argv_exits_2` — the argparse error contract, in-process;
* `test_run_writes_evidence_row_when_fetch_raises` — the #49 blank-padded evidence row at the new `run()` seam, deterministic (the subprocess variant relies on `.invalid` DNS failing through the whole retry stack).

Commit 2 lands the refactor plus the test migration that must ride with it: `FAKE_NETWORK_DRIVER` gains `run_name=''__main__''` (without it the guard never fires under runpy and all five budget tests fail with empty download logs — loud, not silent), the importlib/exec `load_runner` machinery becomes a plain `DownloadRunner.main([...])` call, and the `download_runner` fixture''s five tests call the now-parameterized functions directly. The SIGTERM test now pins that **`main()` installs the handler** while the new import test pins that **importing does not** — the seam from both sides. `_isolate_process_state` stays autouse (calling `main()` still mutates process state).

Commit 3 cashes in the refactor: the `FETCH_CONFIG_PROBE` runpy heredoc becomes an in-process monkeypatch test that pins the same four HTTP contracts plus the new fqdn-parameter threading.

Full suite: 126 passed locally (Windows; the 14 posix-only entrypoint tests run in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)