### PR TITLE
Normalize pano IDs at intake; make the image ledger read-once, append-only

### DIFF
--- a/DownloadRunner.py
+++ b/DownloadRunner.py
@@ -1,6 +1,7 @@
 # !/usr/bin/python3
 
 import argparse
+import csv
 import logging
 import logging.handlers
 import math
@@ -73,27 +74,66 @@ def configure_logging(log_path):
 
 
 def progress_check(csv_pano_log_path):
-    """
-    Checks download status via a csv: log as skipped if downloaded == 1, failure if download == 0.
-    This speeds things up instead of trying to re-download broken links or images.
+    """Read the image ledger once: every ledgered pano id, plus the prior counters seeded into this run's.
+
+    A row means "attempted": downloaded == 1 counts as a prior success (skipped this run), 0 as a prior
+    failure; either way the pano is never re-attempted (README: resume semantics).
     NB: This will not check if the failure was due to internet connection being unavailable etc. so use with caution.
+
+    Row-tolerant on the gsv._load_depth_log model: a line torn by a crash mid-append (or a float minted by
+    the old rewrite path) is skipped, so a damaged ledger degrades to re-attempting a few panos instead of a
+    ParserError that crashes every future run (#55). Reads with csv, not pandas, so the id type can never
+    depend on what the ids happen to look like (#46).
     """
-    df_pano_id_check = pd.read_csv(csv_pano_log_path, dtype={'pano_id': str})
-    df_id_set = set(df_pano_id_check['pano_id'])
-    total_processed = len(df_pano_id_check.index)
-    total_success = df_pano_id_check['downloaded'].sum()
-    total_failed = total_processed - total_success
-    return df_id_set, total_processed, total_success, total_failed
+    ledgered_ids, total_processed, total_success = set(), 0, 0
+    with open(csv_pano_log_path, newline='') as f:
+        for row in csv.reader(f):
+            if len(row) != 2 or row[0] == 'pano_id' or row[1] not in ('0', '1'):
+                continue
+            ledgered_ids.add(row[0])
+            total_processed += 1
+            total_success += row[1] == '1'
+    return ledgered_ids, total_processed, total_success, total_processed - total_success
+
+
+def _normalize_pano_records(records):
+    """Coerce pano_id to str at the intake boundary, drop empty/'tutorial' rows, dedupe keeping the first.
+
+    Numeric (Mapillary) ids otherwise arrive as ints and crash every pano_id[:2] shard slice, and set
+    membership against the ledger's string ids silently misses (#46). Centralised so the CSV and webserver
+    paths cannot drift - the CSV path also gains the tutorial/empty filter the webserver path always had.
+    """
+    unique_ids = set()
+    kept = []
+    for record in records:
+        raw = record.get('pano_id')
+        # A blank CSV cell arrives as float nan, which str() would keep as the id 'nan'.
+        if raw is None or (isinstance(raw, float) and math.isnan(raw)):
+            pano_id = ''
+        else:
+            pano_id = str(raw)
+        if pano_id in unique_ids:
+            continue
+        if not pano_id or pano_id == 'tutorial':
+            print("Pano ID is an empty string or is for tutorial")
+            continue
+        record['pano_id'] = pano_id
+        unique_ids.add(pano_id)
+        kept.append(record)
+    return kept
 
 
 def fetch_pano_ids_csv(metadata_csv_path):
     """
     Loads pano metadata from a CSV file (downloaded from the server). Dedupes on pano_id.
     Expected to include the same columns as /adminapi/panos, notably `source`.
+
+    pano_id is dtype-pinned to str: an all-numeric (Mapillary) column otherwise infers int64 (#46), and one
+    with a single blank cell would infer float64 - whose str() would mint ids like '1.23e+14' - so both the
+    pin here and the normalisation are needed.
     """
-    df_meta = pd.read_csv(metadata_csv_path)
-    df_meta = df_meta.drop_duplicates(subset=['pano_id']).to_dict('records')
-    return df_meta
+    df_meta = pd.read_csv(metadata_csv_path, dtype={'pano_id': str})
+    return _normalize_pano_records(df_meta.to_dict('records'))
 
 
 def fetch_pano_ids_from_webserver(sidewalk_server_fqdn):
@@ -106,8 +146,6 @@ def fetch_pano_ids_from_webserver(sidewalk_server_fqdn):
     --all-panos / has_labels split happens in select_image_panos() - the depth phase wants the whole corpus, so
     filtering here would hide unlabelled panos from it.
     """
-    unique_ids = set()
-    pano_info = []
     # requests with retries and a timeout, like everything else in the repo. The raw http.client this replaced
     # had no timeout (a hung server stalled the nightly run indefinitely), no status check (a 500 or a proxy
     # error page surfaced as an unexplained JSONDecodeError), and never closed the connection (#51).
@@ -130,17 +168,8 @@ def fetch_pano_ids_from_webserver(sidewalk_server_fqdn):
         response.raise_for_status()
         jsondata = response.json()
 
-    for value in jsondata:
-        pano_id = value["pano_id"]
-        if pano_id in unique_ids:
-            continue
-        if pano_id and pano_id != 'tutorial':
-            unique_ids.add(pano_id)
-            pano_info.append(value)
-        else:
-            print("Pano ID is an empty string or is for tutorial")
-    assert len(unique_ids) == len(pano_info)
-    return pano_info
+    # The JSON should carry string ids already; normalising here makes that structural (#46).
+    return _normalize_pano_records(jsondata)
 
 
 def select_image_panos(pano_infos, include_all_panos):
@@ -188,17 +217,13 @@ def filter_supported_sources(pano_infos):
 def download_panorama_images(storage_path, pano_infos, run_start_monotonic=None, max_runtime_minutes=None):
     success_count, skipped_count, fallback_success_count, fail_count, total_completed = 0, 0, 0, 0, 0
 
-    # csv log file for pano_id failures, place in 'storage' folder (alongside pano results)
+    # The attempted-pano ledger, in 'storage' alongside the pano results (see progress_check for semantics).
     csv_pano_log_path = os.path.join(storage_path, "pano_id_log.csv")
-    columns = ['pano_id', 'downloaded']
-    if not exists(csv_pano_log_path):
-        df_pano_id_log = pd.DataFrame(columns=columns)
-        df_pano_id_log.to_csv(csv_pano_log_path, mode='w', header=True, index=False)
+    ledger_existed = exists(csv_pano_log_path)
+    if ledger_existed:
+        df_id_set, prior_total, prior_success, prior_fail = progress_check(csv_pano_log_path)
     else:
-        df_pano_id_log = pd.read_csv(csv_pano_log_path)
-    processed_ids = set(df_pano_id_log['pano_id'])
-
-    df_id_set, prior_total, prior_success, prior_fail = progress_check(csv_pano_log_path)
+        df_id_set, prior_total, prior_success, prior_fail = set(), 0, 0, 0
     # Seed counters from the log so "skipped" in the progress line includes panos already
     # downloaded on previous runs (same semantics as the original code).
     skipped_count = prior_success
@@ -208,49 +233,56 @@ def download_panorama_images(storage_path, pano_infos, run_start_monotonic=None,
     new_panos = sum(1 for p in pano_infos if p['pano_id'] not in df_id_set)
     total_panos = prior_total + new_panos
 
-    for pano_info in pano_infos:
-        pano_id = pano_info['pano_id']
-        if pano_id in df_id_set:
-            continue
-        if max_runtime_minutes is not None and run_start_monotonic is not None:
-            # time.monotonic, not the wall clock: an NTP step or DST transition must not stretch or shrink
-            # the budget (#51).
-            elapsed_minutes = (time.monotonic() - run_start_monotonic) / 60.0
-            if elapsed_minutes >= max_runtime_minutes:
-                print("IMAGEDOWNLOAD: Max runtime of %.1f minutes reached (%.1f elapsed). Stopping." % (max_runtime_minutes, elapsed_minutes))
-                break
-        start_time = time.time()
-        print("IMAGEDOWNLOAD: Processing pano %s " % (pano_id))
-        try:
-            result_code = download_pano(storage_path, pano_info)
-            if result_code == DownloadResult.success:
-                success_count += 1
-            elif result_code == DownloadResult.fallback_success:
-                fallback_success_count += 1
-            elif result_code == DownloadResult.skipped:
-                skipped_count += 1
-            elif result_code == DownloadResult.failure:
+    # One handle held for the whole phase, appended and flushed per row - the depth ledger's pattern (#55).
+    # The old shape opened/closed the file per pano over sshfs, and carried a dead 'update' branch that,
+    # when the #46 dtype mismatch made it reachable, rewrote the ENTIRE file per pano with mode='w' - O(n^2)
+    # per run, and a crash mid-rewrite truncated the only image ledger in place.
+    with open(csv_pano_log_path, 'a', newline='') as ledger_file:
+        ledger = csv.writer(ledger_file)
+        if not ledger_existed:
+            ledger.writerow(['pano_id', 'downloaded'])
+            ledger_file.flush()
+            # Group-writable like depth_log.csv: other lab users' runs append to the same store.
+            os.chmod(csv_pano_log_path, 0o664)
+
+        for pano_info in pano_infos:
+            pano_id = pano_info['pano_id']
+            if pano_id in df_id_set:
+                continue
+            if max_runtime_minutes is not None and run_start_monotonic is not None:
+                # time.monotonic, not the wall clock: an NTP step or DST transition must not stretch or shrink
+                # the budget (#51).
+                elapsed_minutes = (time.monotonic() - run_start_monotonic) / 60.0
+                if elapsed_minutes >= max_runtime_minutes:
+                    print("IMAGEDOWNLOAD: Max runtime of %.1f minutes reached (%.1f elapsed). Stopping." % (max_runtime_minutes, elapsed_minutes))
+                    break
+            start_time = time.time()
+            print("IMAGEDOWNLOAD: Processing pano %s " % (pano_id))
+            try:
+                result_code = download_pano(storage_path, pano_info)
+                if result_code == DownloadResult.success:
+                    success_count += 1
+                elif result_code == DownloadResult.fallback_success:
+                    fallback_success_count += 1
+                elif result_code == DownloadResult.skipped:
+                    skipped_count += 1
+                elif result_code == DownloadResult.failure:
+                    fail_count += 1
+                downloaded = 0 if result_code == DownloadResult.failure else 1
+
+            except Exception as e:
                 fail_count += 1
-            downloaded = 0 if result_code == DownloadResult.failure else 1
+                downloaded = 0
+                logging.error("IMAGEDOWNLOAD: Failed to download pano %s due to error %s", pano_id, str(e))
+            total_completed = success_count + fallback_success_count + fail_count + skipped_count
 
-        except Exception as e:
-            fail_count += 1
-            downloaded = 0
-            logging.error("IMAGEDOWNLOAD: Failed to download pano %s due to error %s", pano_id, str(e))
-        total_completed = success_count + fallback_success_count + fail_count + skipped_count
+            ledger.writerow([pano_id, downloaded])
+            ledger_file.flush()
+            df_id_set.add(pano_id)
 
-        if pano_id not in processed_ids:
-            df_data_append = pd.DataFrame([[pano_id, downloaded]], columns=columns)
-            df_data_append.to_csv(csv_pano_log_path, mode='a', header=False, index=False)
-            processed_ids.add(pano_id)
-        else:
-            df_pano_id_log = pd.read_csv(csv_pano_log_path)
-            df_pano_id_log.loc[df_pano_id_log['pano_id'] == pano_id, 'downloaded'] = downloaded
-            df_pano_id_log.to_csv(csv_pano_log_path, mode='w', header=True, index=False)
-
-        print("IMAGEDOWNLOAD: Completed %d of %d (%d success, %d fallback success, %d failed, %d skipped)"
-              % (total_completed, total_panos, success_count, fallback_success_count, fail_count, skipped_count))
-        print("--- %s seconds ---" % (time.time() - start_time))
+            print("IMAGEDOWNLOAD: Completed %d of %d (%d success, %d fallback success, %d failed, %d skipped)"
+                  % (total_completed, total_panos, success_count, fallback_success_count, fail_count, skipped_count))
+            print("--- %s seconds ---" % (time.time() - start_time))
 
     logging.debug(
         "IMAGEDOWNLOAD: Final result: Completed %d of %d (%d success, %d fallback success, %d failed, %d skipped)",

--- a/DownloadRunner.py
+++ b/DownloadRunner.py
@@ -133,6 +133,13 @@ def fetch_pano_ids_csv(metadata_csv_path):
     pin here and the normalisation are needed.
     """
     df_meta = pd.read_csv(metadata_csv_path, dtype={'pano_id': str})
+    # Fail loudly on a header typo. -c exists for hand-made CSVs, and _normalize_pano_records would
+    # otherwise read every row's missing id as blank and filter the whole file out - a run that downloads
+    # nothing, prints one 'empty string or tutorial' line per row, and exits 0. pd.read_csv ignores dtype
+    # keys for absent columns, so the pin above doesn't catch this either.
+    if 'pano_id' not in df_meta.columns:
+        raise ValueError("%s has no 'pano_id' column; found %r"
+                         % (metadata_csv_path, list(df_meta.columns)))
     return _normalize_pano_records(df_meta.to_dict('records'))
 
 
@@ -238,12 +245,22 @@ def download_panorama_images(storage_path, pano_infos, run_start_monotonic=None,
     # when the #46 dtype mismatch made it reachable, rewrote the ENTIRE file per pano with mode='w' - O(n^2)
     # per run, and a crash mid-rewrite truncated the only image ledger in place.
     with open(csv_pano_log_path, 'a', newline='') as ledger_file:
-        ledger = csv.writer(ledger_file)
+        # lineterminator='\n': csv.writer's excel default is '\r\n', but every existing image ledger was
+        # written by pandas to_csv, whose default is os.linesep - '\n' on the Linux scraper boxes. Without
+        # this pin, appending to a years-old ledger would mix line endings in one file and hand ops greps a
+        # trailing '\r' on the downloaded column.
+        ledger = csv.writer(ledger_file, lineterminator='\n')
         if not ledger_existed:
             ledger.writerow(['pano_id', 'downloaded'])
             ledger_file.flush()
             # Group-writable like depth_log.csv: other lab users' runs append to the same store.
-            os.chmod(csv_pano_log_path, 0o664)
+            try:
+                os.chmod(csv_pano_log_path, 0o664)
+            except OSError:
+                # Lost the exists()/open() race to another user's run: their file, their modes. The ledger is
+                # already open and writable, so this must not take the phase down - the same call in both
+                # downloaders' shard-dir setup swallows it for the same reason.
+                pass
 
         for pano_info in pano_infos:
             pano_id = pano_info['pano_id']

--- a/tests/test_download_runner.py
+++ b/tests/test_download_runner.py
@@ -664,6 +664,16 @@ class TestNumericPanoIds:
 
         assert [record['pano_id'] for record in records] == ['testPanoIdRealAAAAAAAA']
 
+    def test_metadata_csv_without_a_pano_id_column_fails_loudly(self, tmp_path):
+        """drop_duplicates(subset=['pano_id']) used to raise KeyError on a header typo. Normalising by
+        .get('pano_id') would instead read every row as blank and filter the file away - a run that
+        downloads nothing and exits 0. -c exists for hand-made CSVs, so this has to stay loud."""
+        csv_path = tmp_path / 'panos.csv'
+        csv_path.write_text('panoid,source\ntestPanoIdRealAAAAAAAA,gsv\n')
+
+        with pytest.raises(ValueError, match='no .pano_id. column'):
+            DownloadRunner.fetch_pano_ids_csv(str(csv_path))
+
     def test_normalize_pano_records_coerces_filters_and_dedupes(self):
         records = [{'pano_id': 123, 'source': 'mapillary'},
                    {'pano_id': 'abc', 'source': 'gsv'},
@@ -729,6 +739,36 @@ class TestLedgerHygiene:
         storage, _ = call_main(monkeypatch, tmp_path, GSV_CSV_ROWS)
 
         assert os.stat(storage / 'pano_id_log.csv').st_mode & 0o777 == 0o664
+
+    def test_a_failed_chmod_does_not_take_the_phase_down(self, monkeypatch, tmp_path):
+        """Losing the exists()/open() race to another user's run means chmod'ing a file we don't own. The
+        ledger is open and writable either way, so a PermissionError there must not end the image phase -
+        the same reasoning both downloaders apply to their shard-dir chmod."""
+        storage = tmp_path / 'storage'
+        storage.mkdir()
+
+        def denied(*args, **kwargs):
+            raise PermissionError(1, 'Operation not permitted')
+
+        monkeypatch.setattr(DownloadRunner.os, 'chmod', denied)
+        calls = []
+        monkeypatch.setattr(DownloadRunner, 'download_pano', recording_download_pano(calls))
+
+        result = DownloadRunner.download_panorama_images(str(storage), gsv_pano_infos())
+
+        assert calls == GSV_PANO_IDS
+        assert result == (3, 0, 0, 0, 3)
+
+    def test_ledger_rows_are_lf_terminated_like_the_pandas_writer_they_replace(self, monkeypatch, tmp_path):
+        """Every existing image ledger was written by pandas to_csv, whose lineterminator defaults to
+        os.linesep - '\\n' on the Linux scraper boxes. csv.writer's excel default is '\\r\\n', which would mix
+        line endings inside one long-lived production file and put a trailing '\\r' on the downloaded column
+        for anything grepping it."""
+        storage, _ = call_main(monkeypatch, tmp_path, GSV_CSV_ROWS)
+
+        raw = (storage / 'pano_id_log.csv').read_bytes()
+        assert b'\r' not in raw
+        assert raw.startswith(b'pano_id,downloaded\n')
 
 
 def test_pano_list_fetch_session_configuration(monkeypatch):

--- a/tests/test_download_runner.py
+++ b/tests/test_download_runner.py
@@ -27,6 +27,8 @@ import DownloadRunner
 
 import pytest
 
+from conftest import posix_only
+
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 RUNNER = os.path.join(REPO_ROOT, 'DownloadRunner.py')
 CSV_HEADER = 'pano_id,width,height,lat,lng,camera_heading,camera_pitch,source,has_labels\n'
@@ -73,9 +75,10 @@ def test_crash_mid_run_still_writes_a_full_width_log_row(tmp_path):
     """
     storage = tmp_path / 'storage'
     storage.mkdir()
-    # A pano_id_log.csv without the expected columns crashes the image phase on its first read - after the
-    # xml-stub fields are known, before any image or depth fields exist.
-    (storage / 'pano_id_log.csv').write_text('wrong,columns\n1,2\n')
+    # A directory where pano_id_log.csv belongs crashes the image phase on its first ledger open - after the
+    # xml-stub fields are known, before any image or depth fields exist. (A malformed ledger no longer
+    # crashes: the row-tolerant reader skips bad lines, see test_damaged_ledger_rows_are_skipped_not_fatal.)
+    (storage / 'pano_id_log.csv').mkdir()
 
     _, result = run_downloader(tmp_path)
 
@@ -625,6 +628,107 @@ def test_run_writes_evidence_row_when_fetch_raises(tmp_path, monkeypatch):
     assert len(fields) == 18
     assert fields[0] != ''  # a real timestamp: evidence the run started
     assert fields[1:] == [''] * 17  # no phase ran - all blank, not fake zeros
+
+
+# --- Numeric pano ids and ledger hygiene (#46, #55) -----------------------------------------------------------
+
+NUMERIC_PANO_IDS = ['123456789012345', '987654321098765']
+NUMERIC_CSV_ROWS = ''.join('%s,16384,8192,47.6,-122.3,180.0,0.0,gsv,True\n' % p for p in NUMERIC_PANO_IDS)
+
+
+class TestNumericPanoIds:
+    """#46: all-digit (Mapillary-style) pano ids. pandas infers int64 for an all-numeric column, so without a
+    dtype pin the ids arrive as ints - crashing every pano_id[:2] shard slice - and the ledger's two reads
+    (one dtype=str, one not) disagree on membership, so the whole corpus is re-attempted every run while the
+    ledger file is fully rewritten once per pano (#55's real-world trigger). source=gsv on purpose: the dtype
+    path is identical for every source, and gsv avoids Mapillary token plumbing."""
+
+    def test_fetch_pano_ids_csv_returns_string_ids(self, tmp_path):
+        csv_path = tmp_path / 'panos.csv'
+        csv_path.write_text(CSV_HEADER + NUMERIC_CSV_ROWS)
+
+        records = DownloadRunner.fetch_pano_ids_csv(str(csv_path))
+
+        assert [record['pano_id'] for record in records] == NUMERIC_PANO_IDS
+        assert all(isinstance(record['pano_id'], str) for record in records)
+
+    def test_fetch_pano_ids_csv_drops_tutorial_and_empty_rows(self, tmp_path):
+        """Parity with the webserver path's filter - hand-made CSVs are exactly where junk rows appear."""
+        csv_path = tmp_path / 'panos.csv'
+        csv_path.write_text(CSV_HEADER
+                            + 'tutorial,16384,8192,47.6,-122.3,180.0,0.0,gsv,True\n'
+                            + ',16384,8192,47.6,-122.3,180.0,0.0,gsv,True\n'
+                            + 'testPanoIdRealAAAAAAAA,16384,8192,47.6,-122.3,180.0,0.0,gsv,True\n')
+
+        records = DownloadRunner.fetch_pano_ids_csv(str(csv_path))
+
+        assert [record['pano_id'] for record in records] == ['testPanoIdRealAAAAAAAA']
+
+    def test_normalize_pano_records_coerces_filters_and_dedupes(self):
+        records = [{'pano_id': 123, 'source': 'mapillary'},
+                   {'pano_id': 'abc', 'source': 'gsv'},
+                   {'pano_id': '123', 'source': 'mapillary'},   # duplicate once coerced
+                   {'pano_id': 'tutorial'},
+                   {'pano_id': ''},
+                   {'pano_id': None},
+                   {'pano_id': float('nan')}]
+
+        kept = DownloadRunner._normalize_pano_records(records)
+
+        assert [record['pano_id'] for record in kept] == ['123', 'abc']
+        assert all(isinstance(record['pano_id'], str) for record in kept)
+
+    def test_numeric_ids_reach_the_downloader_as_strings(self, monkeypatch, tmp_path):
+        """The network-free stand-in for the production crash: the shard slice pano_id[:2] in every
+        downloader raises TypeError on an int. The recording stub replaces the code that would slice, so the
+        pin here is the boundary type itself."""
+        _, calls = call_main(monkeypatch, tmp_path, NUMERIC_CSV_ROWS)
+
+        assert calls == NUMERIC_PANO_IDS
+        assert all(isinstance(pano_id, str) for pano_id in calls)
+
+    def test_numeric_id_ledger_round_trip_skips_on_second_run(self, monkeypatch, tmp_path):
+        """The core #46 discriminator: a second run over the same numeric-ID corpus must skip every ledgered
+        pano and leave the ledger file byte-for-byte alone. Pre-fix, the str-set/int mismatch re-attempted
+        every pano AND took the whole-file rewrite branch - O(n) per pano, and a truncate-in-place of the
+        only image ledger (#55)."""
+        storage, _ = call_main(monkeypatch, tmp_path, NUMERIC_CSV_ROWS)
+        ledger_path = storage / 'pano_id_log.csv'
+        ledger_before = ledger_path.read_bytes()
+        calls = []
+        monkeypatch.setattr(DownloadRunner, 'download_pano', recording_download_pano(calls))
+
+        DownloadRunner.download_panorama_images(
+            str(storage), DownloadRunner.fetch_pano_ids_csv(str(tmp_path / 'panos.csv')))
+
+        assert calls == [], "the second run must skip every ledgered pano"
+        assert ledger_path.read_bytes() == ledger_before
+
+
+class TestLedgerHygiene:
+    def test_damaged_ledger_rows_are_skipped_not_fatal(self, monkeypatch, tmp_path):
+        """A ledger line torn by a crash mid-append (or stray garbage) must degrade to re-attempting that
+        pano - the depth ledger's semantics (gsv._load_depth_log) - not crash every future run with a
+        ParserError (#55)."""
+        storage = tmp_path / 'storage'
+        storage.mkdir()
+        (storage / 'pano_id_log.csv').write_text(
+            'pano_id,downloaded\n%s,1\ntrunc\na,b,c\n' % GSV_PANO_IDS[0])
+        calls = []
+        monkeypatch.setattr(DownloadRunner, 'download_pano', recording_download_pano(calls))
+
+        result = DownloadRunner.download_panorama_images(str(storage), gsv_pano_infos())
+
+        assert calls == GSV_PANO_IDS[1:], "the intact row skips; the torn rows are not fatal"
+        assert result == (2, 0, 0, 1, 3)
+
+    @posix_only
+    def test_ledger_is_created_group_writable(self, monkeypatch, tmp_path):
+        """The depth ledger is chmod'd 0o664 on creation so other lab users can append on the shared store;
+        the image ledger must match (#55)."""
+        storage, _ = call_main(monkeypatch, tmp_path, GSV_CSV_ROWS)
+
+        assert os.stat(storage / 'pano_id_log.csv').st_mode & 0o777 == 0o664
 
 
 def test_pano_list_fetch_session_configuration(monkeypatch):


### PR DESCRIPTION
Closes #46 and #55 — folded into one PR because #55''s fix *is* deleting the rewrite branch that #46''s dtype mismatch made reachable; the two edit the same fifteen lines. **Stacked on #67** (it builds on the extracted seams; the base is `52-extract-main` and will retarget to master when #67 merges). **No policy change**: resume semantics are byte-identical for string-ID stores — this is a correctness/hygiene PR.

## #46 — what actually goes wrong with numeric (Mapillary) IDs

The issue body''s "duplicate ledger rows, growing without bound" claim is **wrong** — verified against pandas behavior and now pinned by tests. What actually happens on an all-digit corpus:

1. `pd.read_csv` with no dtype infers `int64`, so every `pano_id[:2]` shard slice crashes (`TypeError: ''int'' object is not subscriptable`) — every pano fails.
2. On later runs the skip check misses (str-typed set from `progress_check` vs int ids) → the whole corpus is **re-attempted every run**, and the progress denominator inflates each time.
3. The write-side check *hits* (int and numpy-int hash equal), taking the "update" branch — which re-reads and **rewrites the entire ledger per pano with `mode=''w''`**: O(n²) per run, and a crash mid-rewrite truncates the only image ledger in place. Row counts never grow; that''s why the duplicate-rows story couldn''t occur.

**Fix**: a shared `_normalize_pano_records` (str-coerce, drop NaN/None/empty/`tutorial`, first-wins dedupe) used by *both* intake paths — the CSV path thereby also gains the tutorial/empty filter the webserver path always had — plus a `dtype={''pano_id'': str}` pin in `fetch_pano_ids_csv`. Both are needed: the pin alone leaves `NaN` floats for blank cells, and `str()` alone would mint IDs like `''1.23e+14''` from a float-inferred column.

## #55 — ledger hygiene, on the depth-ledger model

* `progress_check` reads the file **once** with `csv.reader` — row-tolerant like `gsv._load_depth_log`, so a line torn by a crash mid-append degrades to one re-attempt instead of a `ParserError` that crashes every future run — and returns ids + prior counters together. The second, dtype-less read and `processed_ids` are **deleted**, which is #46''s membership bug fixed by removal.
* Writes go through one handle held for the whole phase (append + flush per row, header + `chmod 0o664` on creation) instead of an open/write/close round trip per pano over sshfs.
* The dead update branch (#41''s zombie — unreachable for string IDs since 2021, reachable only via the #46 mismatch) is gone; appends are unconditional.
* Deliberately **not** adopted from depth: degrade-on-`OSError`. An image-ledger failure still crashes the run — the image phase is the run''s purpose, and the #49 `finally` already guarantees the `log.csv` evidence row.

## Test evidence (test-first)

Commit 1 adds 7 tests; **6 fail on the pre-fix code** (the posix chmod pin skips on Windows and is red on CI''s ubuntu): str IDs from the CSV path, the tutorial/empty filter, the normalizer unit, string IDs at the downloader boundary, the core round-trip (second run attempts nothing and the ledger is **byte-for-byte** unchanged — pre-fix it re-attempts everything and rewrites the file), and damaged-row tolerance (pre-fix: `ParserError`). One existing test needed its trigger swapped and it''s worth reviewing: `test_crash_mid_run_still_writes_a_full_width_log_row` used a malformed ledger as its crash trigger, which the row-tolerant reader deliberately no longer crashes on — it now uses a directory at the ledger path, which crashes at the same point under both old and new code.

Full suite: 132 passed locally; posix-only tests run in CI.

**Production note**: existing Mapillary ledgers need no migration — the file text was always fine; only the in-memory typing was wrong. The first nightly after this lands simply stops re-attempting the corpus and the denominator stops inflating.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)