### PR TITLE
Record the artifact-storage standing rule: GitHub or Hugging Face, nothing else

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,17 @@ Everything lives under the storage root, with two-char pano-id prefix sharding:
 
 `config.py` holds `thread_count` (image-phase tile fan-out, default 8), a rotating `headers_list` (randomly picked per request), `proxies` (set to the `http://`/`https://` sentinels to disable), and `depth_min_request_interval` (seconds between depth metadata requests; 0 disables — leave it there unless a canary run shows Google pushing back, since the backfill is a multi-month job).
 
+## Artifact storage (standing rule)
+
+Every research and engineering artifact — datasets, annotations, measurement files, figures,
+scripts, model outputs — lives in **GitHub (this repo or a sibling org repo) or the
+`projectsidewalk` Hugging Face org, nothing else**. Personal cloud storage (Google Drive,
+Dropbox, ad-hoc shared links) is easy to reach for in the moment but doesn't survive people
+moving on: links rot, accounts close, and experiments have had to be re-run because artifacts
+that felt accessible at the time were no longer findable later. Version-controlled, org-owned
+homes are the only storage that outlives any one person's involvement. The bar: a fresh clone
+plus the referenced HF dataset must reproduce every number in `reports/`.
+
 ## Things that are easy to get wrong
 
 - **`log.csv` is positional and headerless.** 18 comma-separated fields, blank-padded. Fields 2–6 are an XML-metadata stub kept at fixed values purely so column positions never shift (that endpoint died in 2022). Blank ≠ 0: blank means the phase never finished. The full table is in README's "Ops notes"; `LOG_CSV_FIELD_COUNT` and `log_analyzer/analyze.py`'s `LOG_COLUMNS` must move together, and a test asserts they do.

--- a/reports/README.md
+++ b/reports/README.md
@@ -12,6 +12,12 @@ These exist because conclusions about external behaviour — Google's endpoints,
 calibrated against real data — get re-argued months later when nobody can reproduce the original
 measurement. An issue thread is not replicable and does not fail CI when it stops being true.
 
+**Where artifacts live:** everything a report rests on goes in **GitHub or the `projectsidewalk`
+Hugging Face org — never personal cloud storage** (Drive/Dropbox/shared links). Those feel accessible
+in the moment but don't survive people moving on, and experiments have had to be re-run because of it.
+Data too large to commit here goes to a HF dataset, referenced by exact revision from the report; the
+repo keeps the manifest and the script that regenerates or re-downloads it.
+
 ## What a report should carry
 
 * **The question**, and why it mattered at the time.


### PR DESCRIPTION
## What

Records a standing project rule in `CLAUDE.md` (new **Artifact storage** section) and `reports/README.md` (next to the `scripts/.cache` convention, where it operationally bites):

> Every research and engineering artifact — datasets, annotations, measurement files, figures, scripts, model outputs — lives in **GitHub or the `projectsidewalk` Hugging Face org, nothing else.**

## Why

Personal cloud storage (Drive/Dropbox/ad-hoc links) feels accessible in the moment but doesn't survive people moving on — links rot, accounts close, and experiments have had to be re-run because the underlying artifacts were no longer findable later. Version-controlled, org-owned homes are the only storage that outlives any one person's involvement.

The bar this sets: a fresh clone plus the referenced HF dataset must reproduce every number in `reports/`.

Requested by @jonfroehlich during planning of the cropper work package (#47/#48/#32/#54), where the ground-truth crop dataset will be the first artifact stored under this rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)