### PR TITLE
Make CropRunner importable and fix the #48 robustness cluster (test-first, 38 new tests)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,8 @@ pip3 install -r requirements.txt
 python3 DownloadRunner.py <fqdn> <storage-dir> [-c <csv>] [--all-panos] [--skip-depth] \
     [--max-runtime MINUTES] [--min-depth-runtime MINUTES] [--max-depth-requests N]
 
-# Cropper
-python3 CropRunner.py (-d <fqdn> | -f <metadata.csv|.json>) [-s <pano-dir>] [-o <crop-dir>]
+# Cropper (exits 1 if any label errored; missing panos alone are not an error)
+python3 CropRunner.py (-d <fqdn> | -f <metadata.csv|.json>) [-s <pano-dir>] [-o <crop-dir>] [--mark-label]
 
 # Log analyzer (needs PS_SFTP_HOST + PS_SFTP_BASE; see README's "Log analyzer")
 python3 log_analyzer/analyze.py [--no-download] [--city <city_id>] [--stale-days N]
@@ -56,7 +56,7 @@ CI (`.github/workflows/tests.yml`) runs the suite on Ubuntu 22.04 / Python 3.10,
 
 ## Architecture
 
-`DownloadRunner.py` and `CropRunner.py` are standalone scripts with **no `if __name__ == "__main__"` guard** — importing either runs its whole flow, which is why `tests/test_log_analyzer.py` reads `LOG_CSV_FIELD_COUNT` out of `DownloadRunner.py` with `ast` rather than importing it. Per-source download logic lives in the `downloaders/` package, which is safe to import.
+`DownloadRunner.py` (#52) and `CropRunner.py` (#48) both follow the same extracted shape: `build_parser()` / `configure_logging()` / `run(...)` / `main(argv=None)` behind an `if __name__ == '__main__'` guard, so **importing either has no side effects** and tests can drive the real flow in-process. (`tests/test_log_analyzer.py` still lifts `LOG_CSV_FIELD_COUNT` out of `DownloadRunner.py` with `ast`, but that is now just avoiding the import cost, not a workaround for a module-scope `parse_args`.) Per-source download logic lives in the `downloaders/` package, which is also safe to import.
 
 **DownloadRunner.py** — orchestrates a nightly run: fetch the pano list, download images, download depth, write one `log.csv` row.
 1. Fetches the pano list from `/adminapi/panos` (or a CSV via `-c`), using a `requests` session with retries and explicit timeouts. Drops empty ids and `'tutorial'`. `filter_supported_sources()` keeps `gsv` and (when `MAPILLARY_ACCESS_TOKEN` is set) `mapillary`; filtered-out panos are deliberately **not** written to `pano_id_log.csv` so a later run can still pick them up.
@@ -71,9 +71,11 @@ CI (`.github/workflows/tests.yml`) runs the suite on Ubuntu 22.04 / Python 3.10,
 - `mapillary.py` resolves `thumb_original_url` via the Graph API and downloads it. Requires `MAPILLARY_ACCESS_TOKEN`.
 
 **CropRunner.py** — extracts per-label crops from downloaded panos.
-1. Loads label metadata from `/adminapi/labels/cvMetadata` (`-d`), or a `.csv`/`.json` file (`-f`). CSV path dedupes on `label_id`.
-2. For each label, opens `<pano-dir>/<pano_id[:2]>/<pano_id>.jpg` and computes a square crop centered at `(pano_x, pano_y)`. Crop size comes from `predict_crop_size()` — an experimentally-fit formula mapping pano-y to distance to crop size, clamped to `[50, 1500]`. Known improvements to make (zoom-aware distance estimation) are in the docstring.
-3. Writes to `<crop-dir>/<label_type_id>/<label_id>.jpg`. `MARK_LABEL = True` draws a dot at the label center inside the crop (a flag at the top of the file, not a CLI arg).
+1. Loads label metadata from `/adminapi/labels/cvMetadata` (`-d`), or a `.csv`/`.json` file (`-f`). Both intakes dedupe on `label_id`; the CSV intake additionally dtype-pins `pano_id` to `str` (the #46 bug class) and requires `REQUIRED_LABEL_COLUMNS` up front, so a header typo is one error naming the file rather than a `KeyError` 200k labels in.
+2. Labels are **grouped by pano**, so each JPEG is decoded exactly once for all its labels — a 16384×8192 pano is ~250 MB decoded. For each label it computes a square crop centered at `(pano_x, pano_y)`; crop size comes from `predict_crop_size()` — an experimentally-fit formula mapping pano-y to distance to crop size, clamped to `[50, 1500]`. Known improvements to make (zoom-aware distance estimation) are in the docstring.
+3. Writes to `<crop-dir>/<label_type_id>/<label_id>.jpg` through `atomic_output_path`, since the crop file is its own resume marker (an existing one is skipped). Rotating `crop.log` lands next to the crops, not the CWD.
+4. `--mark-label` draws a dot at the label center **inside the crop**, never on the shared pano. It is **off by default**: it was a `MARK_LABEL = True` module constant until #48, so every crop this tool produced before then has a (128, 0, 0) dot burned over the feature of interest.
+5. **Nothing in the crop loop is fatal.** `bulk_extract_crops` returns counts where `success + skipped_existing + missing_pano + errors == total` on every path including re-runs; a corrupt pano, malformed row, or failed write is one counted, logged error and retries next run. `main()` exits 1 if `errors` is nonzero — **not** on `missing_pano`, which is the normal state of a city whose scrape is still catching up.
 
 **log_analyzer/analyze.py** — ops monitoring for the nightly scrape; shares no code with the runners.
 1. Reads `log_analyzer/cities.csv`, pulls each city's `log.csv` off the pano store with `sftp -b -` (the store's restricted SFTP subsystem doesn't speak the SCP wire protocol), and caches it in the gitignored `log_analyzer/logs/`. Connection settings come from `PS_SFTP_*` env vars or matching flags — host and base path are required with no defaults, since a wrong default would silently analyze the wrong store.
@@ -132,7 +134,7 @@ See README.md for the full field glossary for `/adminapi/panos` and `/adminapi/l
 
 ## Other directories
 
-- `tests/` — pytest suite (network-free; `streetlevel` is stubbed). Covers the depth phase, the `log.csv` contract, the log analyzer, the depth migrator, and the Docker entrypoint's flag forwarding. `test_streetlevel_api.py` imports the real `streetlevel` to pin API details and skips itself if it isn't installed.
+- `tests/` — pytest suite (network-free; `streetlevel` is stubbed). Covers the depth phase, the `log.csv` contract, the log analyzer, the depth migrator, the Docker entrypoint's flag forwarding, and the cropper (`test_crop_runner.py`: intake, the crop loop's failure taxonomy and count reconciliation, `predict_crop_size` pins). `test_streetlevel_api.py` imports the real `streetlevel` to pin API details and skips itself if it isn't installed.
 - `log_analyzer/` — the log analyzer plus `cities.csv`; `log_analyzer/logs/` is a gitignored local cache.
 - `flag_panos/` — one-off web tool (HTML/JS) from the 2022 depth-endpoint outage. Not wired into the Python scripts; keep unless asked.
 - `samples/` — reference CSV/JSON/XML and a sample pano+crop used for manual testing and as examples for the `-c`/`-f` flags.

--- a/CropRunner.py
+++ b/CropRunner.py
@@ -35,8 +35,22 @@ from downloaders.common import atomic_output_path
 # trusted, but "no limit at all" would also swallow a genuinely corrupt header claiming absurd dimensions.
 _MAX_PANO_PIXELS = 16384 * 8192
 
-# What the crop loop actually reads off every label row; both intakes guarantee these.
+# What the crop loop actually reads off every label row. Only the CSV intake enforces them up front (a
+# header typo is one error naming the file, not a KeyError 200k labels in); the JSON/server intake keeps
+# whatever the payload had, and bulk_extract_crops counts a row missing any of them as one bad label.
 REQUIRED_LABEL_COLUMNS = ('pano_id', 'pano_x', 'pano_y', 'label_type_id', 'label_id')
+
+
+def raise_decompression_bomb_ceiling():
+    """Let Pillow decode our own 134 MP panos without a DecompressionBombWarning on every one.
+
+    Process-level policy, so main() calls it and bulk_extract_crops does not: this rewrites a PIL global
+    that belongs to whoever imported us, and since #52.1 that can be another program. A library caller
+    who wants the ceiling calls this itself; one who doesn't gets a warning, not a failure (Pillow only
+    hard-fails above 2x the threshold, and 134 MP is under 2x the 89 MP default).
+    """
+    if Image.MAX_IMAGE_PIXELS is not None and Image.MAX_IMAGE_PIXELS < _MAX_PANO_PIXELS:
+        Image.MAX_IMAGE_PIXELS = _MAX_PANO_PIXELS
 
 
 def build_parser():
@@ -258,16 +272,13 @@ def bulk_extract_crops(labels_to_crop, path_to_gsv_scrapes, destination_dir, mar
 
     Failure taxonomy: nothing here is fatal. A missing pano image is counted as missing_pano; a corrupt
     pano, malformed row, or failed write is counted as an error and logged; both leave the remaining labels
-    running (#48 - one truncated JPEG used to kill a job tens of thousands of labels in). Crops on disk are
-    the resume marker: existing ones are counted as skipped_existing and everything failed here is simply
-    re-attempted on the next run.
+    running (#48 - one truncated JPEG used to kill a job tens of thousands of labels in). That includes the
+    output side: a full store or a read-only mount is one counted error per label, not an exception out of
+    this function with the counts lost. Crops on disk are the resume marker: existing ones are counted as
+    skipped_existing and everything failed here is simply re-attempted on the next run.
 
     :return: counts dict; success + skipped_existing + missing_pano + errors == total, including on re-runs.
     """
-    # Our own store's biggest panos (134 MP) are over Pillow's default bomb threshold; see _MAX_PANO_PIXELS.
-    if Image.MAX_IMAGE_PIXELS is not None and Image.MAX_IMAGE_PIXELS < _MAX_PANO_PIXELS:
-        Image.MAX_IMAGE_PIXELS = _MAX_PANO_PIXELS
-
     counts = {'total': len(labels_to_crop), 'success': 0, 'skipped_existing': 0,
               'missing_pano': 0, 'errors': 0}
 
@@ -281,7 +292,13 @@ def bulk_extract_crops(labels_to_crop, path_to_gsv_scrapes, destination_dir, mar
             # send down a 'na/nan.jpg' shard path - the _normalize_pano_records lesson.
             if raw_id is None or (isinstance(raw_id, float) and math.isnan(raw_id)):
                 raise ValueError("missing pano_id")
-            pano_id = str(raw_id)
+            # A JSON payload carries '' where a blank CSV cell carries nan; both are missing metadata, but
+            # '' shards to the store root, so unguarded it would be filed as a pano we are still waiting
+            # on rather than a bad row. Stripped because a hand-edited CSV can carry padding and no pano
+            # id in either source has ever contained whitespace.
+            pano_id = str(raw_id).strip()
+            if not pano_id:
+                raise ValueError("empty pano_id")
             pano_x = float(row['pano_x'])
             pano_y = float(row['pano_y'])
             label_type = int(row['label_type_id'])
@@ -295,6 +312,7 @@ def bulk_extract_crops(labels_to_crop, path_to_gsv_scrapes, destination_dir, mar
         labels_by_pano.setdefault(pano_id, []).append((pano_x, pano_y, label_type, label_id))
 
     processed = counts['errors']
+    made_dirs = set()
     for pano_id, labels in labels_by_pano.items():
         pano_img_path = os.path.join(path_to_gsv_scrapes, pano_id[:2], pano_id + ".jpg")
 
@@ -314,19 +332,29 @@ def bulk_extract_crops(labels_to_crop, path_to_gsv_scrapes, destination_dir, mar
                             len(labels), pano_id, pano_img_path, e)
             continue
 
-        with pano:
+        # Not `with pano:` - Image.__exit__ has been a no-op since Pillow 11, so the `with` form silently
+        # stopped closing anything while requirements.txt still allows the older Pillow where it did.
+        # close() is what actually releases the decoded buffer, which is the whole cost decode-once
+        # accepts (~250 MB for a 16384x8192 pano).
+        try:
             for pano_x, pano_y, label_type, label_id in labels:
                 processed += 1
                 print("Cropping label %d of %d (pano %s)" % (processed, counts['total'], pano_id))
 
                 destination_folder = os.path.join(destination_dir, str(label_type))
-                os.makedirs(destination_folder, exist_ok=True)
                 crop_destination = os.path.join(destination_folder, str(label_id) + ".jpg")
 
                 if os.path.exists(crop_destination):
                     counts['skipped_existing'] += 1
                     continue
                 try:
+                    # Once per label type, not per label: exist_ok still costs a stat, and over sshfs
+                    # that is a network round trip for each of a city's ~400k labels. Inside the try
+                    # because an OSError here - a full store, a read-only mount, an sshfs drop - must be
+                    # one counted error like any other write failure, not the end of the run (#48).
+                    if destination_folder not in made_dirs:
+                        os.makedirs(destination_folder, exist_ok=True)
+                        made_dirs.add(destination_folder)
                     make_single_crop(pano, pano_x, pano_y, crop_destination, draw_mark=mark_label)
                 except Exception as e:
                     counts['errors'] += 1
@@ -334,6 +362,8 @@ def bulk_extract_crops(labels_to_crop, path_to_gsv_scrapes, destination_dir, mar
                     continue
                 counts['success'] += 1
                 logging.info('%s.jpg %s %s %s', label_id, pano_id, pano_x, pano_y)
+        finally:
+            pano.close()
 
     print("Finished.")
     print("%d crops extracted, %d already existed, %d skipped because the panorama image was missing, "
@@ -359,19 +389,28 @@ def main(argv=None):
 
     Exceptions propagate, argparse errors exit 2, and an unrecognized -f extension exits with a message -
     not the NameError it used to be.
+
+    :return: 0, or 1 if any label errored. Deliberately not keyed on "did every label produce a crop":
+             missing panos are the normal state of a city whose scrape is still catching up, while
+             `errors` only ever counts things that should not have happened - a corrupt pano, a
+             malformed row, a failed write - so it is the half worth waking someone for.
     """
     args = build_parser().parse_args(argv)
 
-    # exist_ok: re-runs and concurrent invocations race on the exists check.
+    # exist_ok: a re-run, or an operator pre-creating the dir, races on the exists check. Note this is not
+    # a claim that two CropRunners may share an output dir: crops are written through a fixed
+    # <label_id>.jpg.part, so concurrent runs over the same labels would fight over that temp path.
     os.makedirs(args.o, exist_ok=True)
 
     # crop.log lives next to the crops it describes, NOT the CWD (which under Docker/cron is wherever the
     # process happened to start and dies with it - the DownloadRunner #49 lesson).
     configure_logging(os.path.join(args.o, 'crop.log'))
 
-    run(sidewalk_server_fqdn=args.d, label_metadata_file=args.f, gsv_pano_path=args.s,
-        crop_destination_path=args.o, mark_label=args.mark_label)
-    return 0
+    raise_decompression_bomb_ceiling()
+
+    counts = run(sidewalk_server_fqdn=args.d, label_metadata_file=args.f, gsv_pano_path=args.s,
+                 crop_destination_path=args.o, mark_label=args.mark_label)
+    return 1 if counts['errors'] else 0
 
 
 if __name__ == '__main__':

--- a/CropRunner.py
+++ b/CropRunner.py
@@ -9,68 +9,103 @@ the samples/getFullLabelList.sql script) you can pass in the name of that CSV fi
 Additionally, you should have downloaded original panorama images from Street View using DownloadRunner.py. You will
 need to supply the path to the folder containing these files.
 
+The module imports with no side effects (the #52.1 contract): build_parser() / configure_logging() / run() / main()
+are the seams, and `python3 CropRunner.py ...` behaviour lives under the __main__ guard.
 """
 
-import sys
-import logging
-import os
-from PIL import Image, ImageDraw
-import json
-import requests
-from requests.adapters import HTTPAdapter
-import urllib3
-from urllib3.util.retry import Retry
-import pandas as pd
 import argparse
-try:
-    from xml.etree import cElementTree as ET
-except ImportError as e:
-    from xml.etree import ElementTree as ET
+import json
+import logging
+import logging.handlers
+import math
+import os
+import sys
 
-# Mark the center of the crop?
-MARK_LABEL = True
+import pandas as pd
+import requests
+from PIL import Image, ImageDraw
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
-logging.basicConfig(filename='crop.log', level=logging.DEBUG)
+from downloaders.common import atomic_output_path
 
-parser = argparse.ArgumentParser()
-group_parser = parser.add_mutually_exclusive_group(required=True)
-group_parser.add_argument('-d', nargs='?', help='sidewalk_server_domain (preferred over metadata_file) - FDQN of SidewalkWebpage server to fetch label list from, i.e. sidewalk-columbus.cs.washington.edu')
-group_parser.add_argument('-f', nargs='?', help='metadata_file - path to file containing label_ids and their properties. It may be CSV or JSON. i.e. samples/labeldata.csv')
-parser.add_argument('-s', default='/tmp/download_dest/', help='pano_storage_directory - path to directory containing panoramas downloaded using DownloadRunner.py. default=/tmp/download_dest/')
-parser.add_argument('-o', default='/crops/', help='crop_output_directory - path to location for saving the crops. default=/crops/')
-args = parser.parse_args()
+# The largest panos our own downloader writes are 16384x8192 = 134 MP, over Pillow's 89 MP
+# DecompressionBombWarning default; bulk_extract_crops raises the ceiling to this rather than warning once
+# per modern pano (or hard-failing at 2x the threshold). Kept as a named constant, not None: the store is
+# trusted, but "no limit at all" would also swallow a genuinely corrupt header claiming absurd dimensions.
+_MAX_PANO_PIXELS = 16384 * 8192
 
-# FDQN SidewalkWebpage server
-sidewalk_server_fdqn = args.d
-# Path to json or CSV data from database
-label_metadata_file = args.f
-# Path to panoramas downloaded using DownloadRunner.py.
-gsv_pano_path = args.s
-# Path to location for saving the crops
-crop_destination_path = args.o
+# What the crop loop actually reads off every label row; both intakes guarantee these.
+REQUIRED_LABEL_COLUMNS = ('pano_id', 'pano_x', 'pano_y', 'label_type_id', 'label_id')
+
+
+def build_parser():
+    parser = argparse.ArgumentParser()
+    group_parser = parser.add_mutually_exclusive_group(required=True)
+    group_parser.add_argument('-d', help='sidewalk_server_domain (preferred over metadata_file) - FDQN of SidewalkWebpage server to fetch label list from, i.e. sidewalk-columbus.cs.washington.edu')
+    group_parser.add_argument('-f', help='metadata_file - path to file containing label_ids and their properties. It may be CSV or JSON. i.e. samples/labeldata.csv')
+    parser.add_argument('-s', default='/tmp/download_dest/', help='pano_storage_directory - path to directory containing panoramas downloaded using DownloadRunner.py. default=/tmp/download_dest/')
+    parser.add_argument('-o', default='/crops/', help='crop_output_directory - path to location for saving the crops. default=/crops/')
+    parser.add_argument('--mark-label', action='store_true', help='Draw a dot at the label position in every crop. Debugging aid - deliberately OFF by default, because these crops are ML training data and a synthetic marker painted over the feature of interest is exactly what a model would learn instead of the feature.')
+    return parser
+
+
+def configure_logging(log_path):
+    """Set up run-wide logging to log_path (crop.log next to the crops, not the CWD).
+
+    The DownloadRunner shape (#49): rotation bounds growth, urllib3's and PIL's per-operation DEBUG chatter
+    is capped at WARNING, and if the log file can't be opened we fall back to stderr with one loud warning
+    rather than killing the run.
+    """
+    try:
+        handler = logging.handlers.RotatingFileHandler(log_path, maxBytes=10 * 1024 * 1024, backupCount=3)
+        fallback_error = None
+    except OSError as e:
+        handler = logging.StreamHandler()
+        fallback_error = e
+    handler.setFormatter(logging.Formatter(logging.BASIC_FORMAT))
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
+    root.addHandler(handler)
+    if fallback_error is not None:
+        logging.warning("Could not open %s (%s); logging to stderr for this run", log_path, fallback_error)
+    logging.getLogger('urllib3').setLevel(logging.WARNING)
+    logging.getLogger('PIL').setLevel(logging.WARNING)
+
 
 def request_session():
-    """
-    Sets up a request session to handle server HTTP requests, retrying in case of errors.
-    :return: session
+    """A hardened session for the metadata fetch - the DownloadRunner #51 shape.
+
+    Both schemes are mounted so a redirect hop to http:// can't silently fall back to the retry-less default
+    adapter, and trust_env is off so the run doesn't newly honour HTTP(S)_PROXY / REQUESTS_CA_BUNDLE on
+    whatever box it lands on. read=0: retrying a slow admin query is just hammering it five more times.
     """
     session = requests.Session()
-    retries = Retry(total=5, connect=5, status_forcelist=[429, 500, 502, 503, 504], backoff_factor=1, raise_on_status=False)
+    session.trust_env = False
+    retries = Retry(total=5, connect=5, read=0, status_forcelist=[429, 500, 502, 503, 504], backoff_factor=1)
     adapter = HTTPAdapter(max_retries=retries)
     session.mount('https://', adapter)
+    session.mount('http://', adapter)
     return session
+
 
 def fetch_label_ids_csv(metadata_csv_path):
     """
-    Reads metadata from a csv. Useful for old csv formats of cvMetadata such as cv-metadata-seattle.csv
-    :param metadata_csv_path: The path to the metadata csv file and the file's name eg. sample/metadata-seattle.csv
-    :return: A list of dicts containing the follow metadata: pano_id, source, pano_x, pano_y, zoom, label_type_id,
-             camera_heading, heading, pitch, label_id, width, height, tile_width, tile_height, image_date, imagery_type,
-             pano_lat, pano_lng, label_lat, label_lng, computation_method, copyright
+    Reads metadata from a csv. Useful for old csv formats of cvMetadata such as cv-metadata-seattle.csv.
+    Dedupes on label_id.
+
+    pano_id is dtype-pinned to str: an all-numeric (Mapillary) column otherwise infers int64 and crashes
+    every pano_id[:2] shard slice - the same #46 intake bug DownloadRunner.fetch_pano_ids_csv fixed. The
+    column guard exists because pd.read_csv ignores dtype keys for absent columns, so a header typo would
+    otherwise surface as a KeyError deep in the crop loop instead of an error naming the file.
     """
-    df_meta = pd.read_csv(metadata_csv_path)
-    df_meta = df_meta.drop_duplicates(subset=['label_id']).to_dict('records')
-    return df_meta
+    df_meta = pd.read_csv(metadata_csv_path, dtype={'pano_id': str})
+    missing = [c for c in REQUIRED_LABEL_COLUMNS if c not in df_meta.columns]
+    if missing:
+        raise ValueError("%s is missing required column(s) %r; found %r"
+                         % (metadata_csv_path, missing, list(df_meta.columns)))
+    return df_meta.drop_duplicates(subset=['label_id']).to_dict('records')
+
 
 def json_to_list(jsondata):
     """
@@ -90,45 +125,58 @@ def json_to_list(jsondata):
             label_info.append(value)
         else:
             print("Duplicate label ID")
-    assert len(unique_label_ids) == len(label_info)
     return label_info
+
 
 def fetch_cvMetadata_from_file(metadata_json_path):
     """
-    Reads json file to exctact labels.
-    :param metadata_file_path: the path of the json file containing all label ids and their associated data.
-    :return: A list of dicts containing the following metadata: label_id, pano_id, label_type_id, agree_count,
-    disagree_count, notsure_count, pano_width, pano_height, pano_x, pano_y, canvas_width, canvas_height, canvas_x,
-    canvas_y, zoom, heading, pitch, camera_heading, camera_pitch, source
+    Reads json file to extract labels.
+    :param metadata_json_path: the path of the json file containing all label ids and their associated data.
+    :return: A list of dicts, one per label (see json_to_list).
     """
     with open(metadata_json_path) as json_file:
         json_meta = json.load(json_file)
     return json_to_list(json_meta)
 
-# https://stackoverflow.com/questions/54356759/python-requests-how-to-determine-response-code-on-maxretries-exception
+
 def fetch_cvMetadata_from_server(server_fdqn):
     """
-    Function that uses HTTP request to server to fetch cvMetadata. Then parses the data to json and transforms it
-    into list of dicts. Each element is associated with a single label.
-    :return: list of labels
+    Fetch cvMetadata over HTTP and transform it into a list of dicts, one per label.
+
+    Any request failure - connection, HTTP status, retries exhausted - is logged with the actual exception
+    text and exits 1. (The old handler pair missed ConnectionError entirely and logged a placeholder-less
+    'Retries: '.format(e) that dropped the exception, #48.)
     """
     url = 'https://' + server_fdqn + '/adminapi/labels/cvMetadata'
-    session = request_session()
     try:
         print("Getting metadata from web server")
-        response = session.get(url)
-        response.raise_for_status()
-    except requests.exceptions.HTTPError as e:
-        logging.error('HTTPError: {}'.format(e))
-        print("Cannot fetch metadata from webserver. Check log file.")
-        sys.exit(1)
-    except urllib3.exceptions.MaxRetryError as e:
-        logging.error('Retries: '.format(e))
+        with request_session() as session:
+            # (connect, read) timeouts; generous read half because the server may buffer the whole JSON
+            # before its first byte - the DownloadRunner /adminapi/panos rationale.
+            response = session.get(url, timeout=(30, 600))
+            response.raise_for_status()
+            jsondata = response.json()
+    except requests.exceptions.RequestException as e:
+        logging.error('Fetching cvMetadata from %s failed: %s', url, e)
         print("Cannot fetch metadata from webserver. Check log file.")
         sys.exit(1)
 
-    jsondata = response.json()
     return json_to_list(jsondata)
+
+
+def load_label_metadata(sidewalk_server_fdqn, label_metadata_file):
+    """Dispatch to the right intake for -d / -f, with a clear error for an unrecognized -f extension
+    (which used to fall through to a NameError, #48)."""
+    if label_metadata_file is not None:
+        extension = os.path.splitext(label_metadata_file)[1]
+        if extension.lower() == ".csv":
+            return fetch_label_ids_csv(label_metadata_file)
+        if extension.lower() == ".json":
+            return fetch_cvMetadata_from_file(label_metadata_file)
+        sys.exit("CropRunner: unrecognized metadata file extension %r (expected .csv or .json): %s"
+                 % (extension, label_metadata_file))
+    return fetch_cvMetadata_from_server(sidewalk_server_fdqn)
+
 
 def predict_crop_size(pano_y, pano_height):
     """
@@ -160,93 +208,171 @@ def predict_crop_size(pano_y, pano_height):
     return crop_size
 
 
-def make_single_crop(path_to_image, pano_x, pano_y, output_filename, draw_mark=False):
+def make_single_crop(pano, pano_x, pano_y, output_filename, draw_mark=False):
     """
-    Makes a crop around the object of interest
-    :param path_to_image: where the GSV pano is stored
+    Makes a crop around the object of interest and saves it atomically.
+
+    :param pano: an open PIL.Image, or a path to one. bulk_extract_crops opens each pano once and passes
+                 the image (a 16384x8192 pano is ~250 MB decoded; re-opening per label decoded it once per
+                 label); the path form is kept for one-off use.
     :param pano_x: x-pixel of label on the GSV image
     :param pano_y: y-pixel of label on the GSV image
     :param output_filename: name of file for saving
-    :param draw_mark: if a dot should be drawn in the centre of the object/image
+    :param draw_mark: if a dot should be drawn at the label position in the crop
     :return: none
     """
-    pano = Image.open(path_to_image)
-    draw = ImageDraw.Draw(pano)
+    close_after = False
+    if not hasattr(pano, 'crop'):
+        pano = Image.open(pano)
+        close_after = True
+    try:
+        pano_height = pano.size[1]
 
-    pano_width = pano.size[0]
-    pano_height = pano.size[1]
-    print(pano_width, pano_height)
+        crop_size = predict_crop_size(pano_y, pano_height)
+        top_left_x = pano_x - crop_size / 2
+        top_left_y = pano_y - crop_size / 2
+        cropped_square = pano.crop((top_left_x, top_left_y, top_left_x + crop_size, top_left_y + crop_size))
 
-    predicted_crop_size = predict_crop_size(pano_y, pano_height)
-    crop_width = predicted_crop_size
-    crop_height = predicted_crop_size
+        if draw_mark:
+            # Draw on the crop, never the source pano: the pano image is shared by every label on it, so a
+            # mark on the source would leak this label's dot into its neighbours' crops. Pillow rounds the
+            # crop box the same way round() does, hence the round() here to land on the true label pixel.
+            draw = ImageDraw.Draw(cropped_square)
+            r = 10
+            centre_x = pano_x - round(top_left_x)
+            centre_y = pano_y - round(top_left_y)
+            draw.ellipse((centre_x - r, centre_y - r, centre_x + r, centre_y + r), fill=128)
 
-    r = 10
-    if draw_mark:
-        draw.ellipse((pano_x - r, pano_y - r, pano_x + r, pano_y + r), fill=128)
-
-    print("Plotting at " + str(pano_x) + "," + str(pano_y))
-
-    top_left_x = pano_x - crop_width / 2
-    top_left_y = pano_y - crop_height / 2
-    cropped_square = pano.crop((top_left_x, top_left_y, top_left_x + crop_width, top_left_y + crop_height))
-    cropped_square.save(output_filename)
-
-    return
+        # The crop file is its own resume marker (bulk_extract_crops skips existing ones), so a mid-write
+        # crash must not leave a truncated .jpg the next run trusts - same contract as every write in
+        # downloaders/. format= is explicit because the temp path ends in .part, not .jpg.
+        with atomic_output_path(output_filename) as tmp_path:
+            cropped_square.save(tmp_path, format='JPEG')
+    finally:
+        if close_after:
+            pano.close()
 
 
 def bulk_extract_crops(labels_to_crop, path_to_gsv_scrapes, destination_dir, mark_label=False):
-    total_labels = len(labels_to_crop)
-    no_metadata_fail = 0
-    no_pano_fail = 0
-    success = 0
+    """Extract one crop per label into <destination_dir>/<label_type_id>/<label_id>.jpg.
 
+    Failure taxonomy: nothing here is fatal. A missing pano image is counted as missing_pano; a corrupt
+    pano, malformed row, or failed write is counted as an error and logged; both leave the remaining labels
+    running (#48 - one truncated JPEG used to kill a job tens of thousands of labels in). Crops on disk are
+    the resume marker: existing ones are counted as skipped_existing and everything failed here is simply
+    re-attempted on the next run.
+
+    :return: counts dict; success + skipped_existing + missing_pano + errors == total, including on re-runs.
+    """
+    # Our own store's biggest panos (134 MP) are over Pillow's default bomb threshold; see _MAX_PANO_PIXELS.
+    if Image.MAX_IMAGE_PIXELS is not None and Image.MAX_IMAGE_PIXELS < _MAX_PANO_PIXELS:
+        Image.MAX_IMAGE_PIXELS = _MAX_PANO_PIXELS
+
+    counts = {'total': len(labels_to_crop), 'success': 0, 'skipped_existing': 0,
+              'missing_pano': 0, 'errors': 0}
+
+    # Parse rows up front and group labels by pano (preserving first-seen order), so each pano JPEG is
+    # decoded exactly once for all its labels.
+    labels_by_pano = {}
     for row in labels_to_crop:
-        pano_id = row['pano_id']
-        print(pano_id)
-        pano_x = float(row['pano_x'])
-        pano_y = float(row['pano_y'])
-        label_type = int(row['label_type_id'])
-        label_id = int(row['label_id'])
+        try:
+            raw_id = row['pano_id']
+            # A blank CSV cell arrives as float nan, which str() would keep as the id 'nan' and quietly
+            # send down a 'na/nan.jpg' shard path - the _normalize_pano_records lesson.
+            if raw_id is None or (isinstance(raw_id, float) and math.isnan(raw_id)):
+                raise ValueError("missing pano_id")
+            pano_id = str(raw_id)
+            pano_x = float(row['pano_x'])
+            pano_y = float(row['pano_y'])
+            label_type = int(row['label_type_id'])
+            label_id = int(row['label_id'])
+            if not (math.isfinite(pano_x) and math.isfinite(pano_y)):
+                raise ValueError("non-finite label position (%r, %r)" % (row['pano_x'], row['pano_y']))
+        except (KeyError, TypeError, ValueError) as e:
+            counts['errors'] += 1
+            logging.warning("Skipping malformed label row %r: %s", row, e)
+            continue
+        labels_by_pano.setdefault(pano_id, []).append((pano_x, pano_y, label_type, label_id))
 
+    processed = counts['errors']
+    for pano_id, labels in labels_by_pano.items():
         pano_img_path = os.path.join(path_to_gsv_scrapes, pano_id[:2], pano_id + ".jpg")
 
-        print(f'Cropping label {1 + no_pano_fail + no_metadata_fail + success} of {total_labels}')
-        print(pano_img_path)
-        # Extract the crop.
-        if os.path.exists(pano_img_path):
-            destination_folder = os.path.join(destination_dir, str(label_type))
-            os.makedirs(destination_folder, exist_ok=True)
+        if not os.path.exists(pano_img_path):
+            counts['missing_pano'] += len(labels)
+            processed += len(labels)
+            print("Panorama image not found: %s (%d labels skipped)" % (pano_img_path, len(labels)))
+            logging.warning("Skipped %d labels on pano %s due to missing image.", len(labels), pano_id)
+            continue
 
-            crop_destination = os.path.join(destination_dir, str(label_type), str(label_id) + ".jpg")
+        try:
+            pano = Image.open(pano_img_path)
+        except Exception as e:
+            counts['errors'] += len(labels)
+            processed += len(labels)
+            logging.warning("Skipped %d labels on pano %s: cannot open %s (%s)",
+                            len(labels), pano_id, pano_img_path, e)
+            continue
 
-            if not os.path.exists(crop_destination):
-                make_single_crop(pano_img_path, pano_x, pano_y, crop_destination, draw_mark=mark_label)
-                print("Successfully extracted crop to " + str(label_id) + ".jpg")
-                logging.info(f'{str(label_id)}.jpg {pano_id} {str(pano_x)} {str(pano_y)} {str(label_id)}')
-                logging.info("---------------------------------------------------")
-                success += 1
-        else:
-            no_pano_fail += 1
-            print("Panorama image not found.")
-            logging.warning("Skipped label id " + str(label_id) + " due to missing image.")
+        with pano:
+            for pano_x, pano_y, label_type, label_id in labels:
+                processed += 1
+                print("Cropping label %d of %d (pano %s)" % (processed, counts['total'], pano_id))
+
+                destination_folder = os.path.join(destination_dir, str(label_type))
+                os.makedirs(destination_folder, exist_ok=True)
+                crop_destination = os.path.join(destination_folder, str(label_id) + ".jpg")
+
+                if os.path.exists(crop_destination):
+                    counts['skipped_existing'] += 1
+                    continue
+                try:
+                    make_single_crop(pano, pano_x, pano_y, crop_destination, draw_mark=mark_label)
+                except Exception as e:
+                    counts['errors'] += 1
+                    logging.warning("Failed to crop label %d on pano %s: %s", label_id, pano_id, e)
+                    continue
+                counts['success'] += 1
+                logging.info('%s.jpg %s %s %s', label_id, pano_id, pano_x, pano_y)
 
     print("Finished.")
-    print(f"{no_pano_fail} extractions failed because panorama image was not found.")
-    print(f"{no_metadata_fail} extractions failed because metadata was not found.")
-    print(f"{success} extractions were successful.")
-    return
+    print("%d crops extracted, %d already existed, %d skipped because the panorama image was missing, "
+          "%d errors, of %d labels total."
+          % (counts['success'], counts['skipped_existing'], counts['missing_pano'],
+             counts['errors'], counts['total']))
+    return counts
 
 
-print("Cropping labels")
+def run(sidewalk_server_fqdn, label_metadata_file, gsv_pano_path, crop_destination_path, mark_label=False):
+    """Load the label metadata and extract every crop - the whole job, minus process-level setup.
 
-if label_metadata_file is not None:
-    file_path = os.path.splitext(label_metadata_file)
-    if file_path[-1] == ".csv":
-        label_infos = fetch_label_ids_csv(label_metadata_file)
-    elif file_path[-1] == ".json":
-        label_infos = fetch_cvMetadata_from_file(label_metadata_file)
-else:
-    label_infos = fetch_cvMetadata_from_server(sidewalk_server_fdqn)
+    main() owns argv parsing, directory creation, and logging; this seam takes plain arguments so tests can
+    drive the real intake -> crop loop in-process (the #52.1 shape).
+    """
+    print("Cropping labels")
+    label_infos = load_label_metadata(sidewalk_server_fqdn, label_metadata_file)
+    return bulk_extract_crops(label_infos, gsv_pano_path, crop_destination_path, mark_label=mark_label)
 
-bulk_extract_crops(label_infos, gsv_pano_path, crop_destination_path, mark_label=MARK_LABEL)
+
+def main(argv=None):
+    """Process-level setup, then run(): everything a `python3 CropRunner.py ...` invocation does.
+
+    Exceptions propagate, argparse errors exit 2, and an unrecognized -f extension exits with a message -
+    not the NameError it used to be.
+    """
+    args = build_parser().parse_args(argv)
+
+    # exist_ok: re-runs and concurrent invocations race on the exists check.
+    os.makedirs(args.o, exist_ok=True)
+
+    # crop.log lives next to the crops it describes, NOT the CWD (which under Docker/cron is wherever the
+    # process happened to start and dies with it - the DownloadRunner #49 lesson).
+    configure_logging(os.path.join(args.o, 'crop.log'))
+
+    run(sidewalk_server_fqdn=args.d, label_metadata_file=args.f, gsv_pano_path=args.s,
+        crop_destination_path=args.o, mark_label=args.mark_label)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/README.md
+++ b/README.md
@@ -69,18 +69,23 @@ Panos with any other `source` value are skipped with a warning.
 
 Usage:
 ```python
-python CropRunner.py [-h] (-d [D] | -f [F]) [-s S] [-c C]
+python CropRunner.py [-h] (-d D | -f F) [-s S] [-o O] [--mark-label]
 ```
 * To fetch label metadata from webserver or a file, use respectively (mutually exclusive, required):
   * ``-d <project-sidewalk-url>``
-  * ``-f <path-to-label-metadata-file>``
+  * ``-f <path-to-label-metadata-file>`` — `.csv` or `.json`
 * ``-s <path-to-panoramas-dir>`` (optional). Specify if using a different directory containing panoramas. Panoramas are used to crop the labels.
 * ``-o <path-of-crop-dir>`` (optional). Specify if want to set a different directory for crops to be stored.
+* ``--mark-label`` (optional). Draw a dot at the label position inside each crop. **A debugging aid — leave it off for training data.**
 
 As an example:
 ```python
 python CropRunner.py -d sidewalk-columbus.cs.washington.edu -s /sidewalk/columbus/panos/ -o /sidewalk/columbus/crops/
 ```
+
+The run writes a rotating `crop.log` into the crop directory, prints a per-outcome summary, and **exits 1 if any label errored** (a corrupt pano, a malformed metadata row, a failed write) so a cron wrapper can alert. Labels waiting on a pano that hasn't been downloaded yet are reported separately and are *not* an error — the pano store is scraped independently and legitimately lags the label list. Every failure is retried on the next run, since the crop file is its own resume marker: existing crops are skipped.
+
+**Note** Crops produced before the `--mark-label` flag existed all carry a burned-in dark-red dot at the label position: marking used to be a `MARK_LABEL = True` constant at the top of the file and was on for every run. If you are reusing an older crop set for training, that dot sits directly over the feature of interest and is exactly what a model will learn instead of the feature. Re-crop rather than reuse.
 
 **Note** You will likely want to filter out labels where `disagree_count > agree_count`. These are based on human-provided validations from other Project Sidewalk users. This is not written in the code by default. There is also an option for a filter that is even more strict. This of course has the tradeoff of using less data, so this depends on the the needs of your project: more data vs more accurate data. To do this, you would query the `/v2/access/attributesWithLabels` API endpoint for the city you're looking at. Then you would only include labels where the `label_id` is also present in the attributesWithLabels API. This is a more aggressive filter that removes labels from some users that we suspect are providing low quality data based on some heuristics.
 

--- a/tests/test_crop_runner.py
+++ b/tests/test_crop_runner.py
@@ -190,12 +190,15 @@ class TestMetadataIntake:
         assert os.path.exists(crop_path(out, 1, 1))
 
     def test_csv_pano_ids_stay_strings(self, crop_runner, tmp_path):
-        """An all-numeric pano_id column otherwise infers int64 and pano_id[:2] raises TypeError — the
-        exact #46 intake bug DownloadRunner already fixed with a dtype pin."""
+        """The #46 intake bug, in its discriminating form: an all-numeric pano_id column with one blank
+        cell infers float64 without a dtype pin, minting ids like '1234567890.0' whose shard paths quietly
+        miss every real pano. The good row must still crop and the blank-id row must count as an error,
+        not walk off to a 'na/nan.jpg' path."""
         store, out = tmp_path / 'store', tmp_path / 'crops'
         put_pano(store, '1234567890')
         csv_file = tmp_path / 'labels.csv'
-        write_labels_csv(csv_file, [label_row(pano_id='1234567890')])
+        write_labels_csv(csv_file, [label_row(pano_id='1234567890', label_id=1),
+                                    label_row(pano_id='', label_id=2)])
         assert crop_runner.main(['-f', str(csv_file), '-s', str(store), '-o', str(out)]) == 0
         assert os.path.exists(crop_path(out, 1, 1))
 
@@ -375,11 +378,12 @@ class TestBulkExtractCrops:
         labels = [{'pano_id': 'testpano0001', 'label_id': 1},           # no coordinates at all
                   label_row(label_id=2, pano_x='not-a-number'),
                   label_row(label_id=3, pano_x=float('nan')),
-                  label_row(label_id=4)]
+                  label_row(label_id=4, pano_id=float('nan')),          # a blank CSV cell arrives as nan
+                  label_row(label_id=5)]
         counts = crop_runner.bulk_extract_crops(labels, str(store), str(out))
-        assert counts['errors'] == 3
+        assert counts['errors'] == 4
         assert counts['success'] == 1
-        assert os.path.exists(crop_path(out, 1, 4))
+        assert os.path.exists(crop_path(out, 1, 5))
 
     def test_crops_are_written_atomically(self, crop_runner, tmp_path, monkeypatch):
         """A crash mid-save must not leave a truncated .jpg that the next run's exists() check treats as

--- a/tests/test_crop_runner.py
+++ b/tests/test_crop_runner.py
@@ -1,0 +1,527 @@
+"""Tests for CropRunner.py: importability, metadata intake, the crop loop, and the #48 robustness cluster.
+
+CropRunner has never had a test (#57): pre-fix it runs argparse and its whole flow at import, so most of
+this file fails on the pre-fix code with SystemExit(2) out of `import CropRunner` — that inability to even
+import is the first defect under test. The target shape is DownloadRunner's post-#52.1 contract:
+build_parser() / main(argv) / run(...) seams, an import with no side effects, and per-item error handling
+that cannot take down a whole run (#48).
+
+No network anywhere: metadata comes from -f files or stubbed sessions, panos are synthetic JPEGs written
+into a tmp store with the production <pano_id[:2]>/<pano_id>.jpg sharding.
+"""
+
+import csv
+import json
+import logging
+import os
+import sys
+
+import pytest
+import requests
+from PIL import Image
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# The columns of samples/labeldata.csv (the getFullLabelList.sql shape) — the minimal CSV intake surface.
+CSV_COLUMNS = ['pano_id', 'source', 'pano_x', 'pano_y', 'label_type_id',
+               'camera_heading', 'heading', 'pitch', 'label_id']
+
+# A 512x256 pano with a label at y=128 predicts a 248.3 px crop — comfortably interior, so none of these
+# tests depend on the (separately tracked, #47) edge/seam behaviour.
+PANO_SIZE = (512, 256)
+INTERIOR_Y = 128
+
+
+def label_row(pano_id='testpano0001', pano_x=200, pano_y=INTERIOR_Y, label_type_id=1, label_id=1):
+    return {'pano_id': pano_id, 'pano_x': pano_x, 'pano_y': pano_y,
+            'label_type_id': label_type_id, 'label_id': label_id}
+
+
+def write_labels_csv(path, rows):
+    """Write rows (dicts with the label_row keys) as a labeldata.csv-shaped file."""
+    with open(path, 'w', newline='') as f:
+        writer = csv.DictWriter(f, fieldnames=CSV_COLUMNS)
+        writer.writeheader()
+        for row in rows:
+            full = {'source': 'gsv', 'camera_heading': 180.0, 'heading': 90.0, 'pitch': -10.0}
+            full.update(row)
+            writer.writerow(full)
+
+
+def put_pano(store_dir, pano_id, size=PANO_SIZE, color=(255, 255, 255), square_at=None):
+    """Write a synthetic pano JPEG into the store's <pano_id[:2]>/<pano_id>.jpg layout.
+
+    square_at: optionally burn a 20x20 black square centred there, as a JPEG-robust landmark.
+    """
+    shard = os.path.join(str(store_dir), pano_id[:2])
+    os.makedirs(shard, exist_ok=True)
+    img = Image.new('RGB', size, color)
+    if square_at is not None:
+        x, y = square_at
+        for dx in range(-10, 10):
+            for dy in range(-10, 10):
+                if 0 <= x + dx < size[0] and 0 <= y + dy < size[1]:
+                    img.putpixel((x + dx, y + dy), (0, 0, 0))
+    path = os.path.join(shard, pano_id + '.jpg')
+    img.save(path, quality=95)
+    return path
+
+
+def crop_path(out_dir, label_type_id, label_id):
+    return os.path.join(str(out_dir), str(label_type_id), str(label_id) + '.jpg')
+
+
+@pytest.fixture
+def crop_runner():
+    """Import CropRunner. On the pre-fix code this raises SystemExit(2) out of module-scope argparse,
+    which is exactly the importability defect the refactor removes."""
+    import CropRunner
+    return CropRunner
+
+
+@pytest.fixture(autouse=True)
+def _isolate_logging_state():
+    """configure_logging mutates the root logger and urllib3's level; snapshot and restore around every
+    test so in-process main() calls can't leak handlers into each other (the test_download_runner
+    _isolate_process_state pattern, minus the SIGTERM handling CropRunner doesn't do)."""
+    root = logging.getLogger()
+    before_handlers = list(root.handlers)
+    before_level = root.level
+    urllib3_level = logging.getLogger('urllib3').level
+    yield
+    for handler in list(root.handlers):
+        if handler not in before_handlers:
+            root.removeHandler(handler)
+            handler.close()
+    root.setLevel(before_level)
+    logging.getLogger('urllib3').setLevel(urllib3_level)
+
+
+# ---------------------------------------------------------------------------
+# Importability and parser contract
+# ---------------------------------------------------------------------------
+
+class TestImportIsSideEffectFree:
+
+    def test_import_is_side_effect_free(self, monkeypatch, tmp_path):
+        """Importing the module must not parse argv, configure logging, write crop.log, or crop anything.
+
+        Pre-fix: module-scope parse_args() raises SystemExit(2) under pytest's argv, and a bare import
+        with plausible argv would run the whole flow and drop crop.log in the CWD."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(sys, 'argv', ['CropRunner.py'])
+        monkeypatch.delitem(sys.modules, 'CropRunner', raising=False)
+        root_handlers_before = list(logging.getLogger().handlers)
+
+        import CropRunner  # noqa: F401
+
+        assert list(logging.getLogger().handlers) == root_handlers_before
+        assert list(tmp_path.iterdir()) == []
+
+    def test_module_exposes_the_extracted_seams(self, crop_runner):
+        for name in ('build_parser', 'configure_logging', 'run', 'main'):
+            assert callable(getattr(crop_runner, name, None)), name
+
+
+class TestParser:
+
+    def test_requires_a_metadata_source(self, crop_runner):
+        with pytest.raises(SystemExit) as e:
+            crop_runner.build_parser().parse_args([])
+        assert e.value.code == 2
+
+    def test_d_and_f_are_mutually_exclusive(self, crop_runner):
+        with pytest.raises(SystemExit) as e:
+            crop_runner.build_parser().parse_args(['-d', 'x.invalid', '-f', 'y.csv'])
+        assert e.value.code == 2
+
+    def test_bare_dash_d_is_a_parse_error(self, crop_runner):
+        """Pre-fix nargs='?' let `-d` (no value) through as None, which then fell into the -f branch's
+        else and requested https://None/adminapi/... — a flag with a missing value must fail at parse
+        time instead."""
+        with pytest.raises(SystemExit) as e:
+            crop_runner.build_parser().parse_args(['-d'])
+        assert e.value.code == 2
+
+    def test_defaults(self, crop_runner):
+        args = crop_runner.build_parser().parse_args(['-d', 'sidewalk-test.invalid'])
+        assert args.s == '/tmp/download_dest/'
+        assert args.o == '/crops/'
+        assert args.mark_label is False
+
+    def test_mark_label_is_a_flag(self, crop_runner):
+        """The old MARK_LABEL=True module constant burned a dot into every crop ever produced (#48);
+        marking must be an explicit opt-in."""
+        args = crop_runner.build_parser().parse_args(['-d', 'x.invalid', '--mark-label'])
+        assert args.mark_label is True
+
+
+# ---------------------------------------------------------------------------
+# Metadata intake
+# ---------------------------------------------------------------------------
+
+class TestMetadataIntake:
+
+    def test_unknown_extension_exits_with_a_clear_error(self, crop_runner, tmp_path, capsys):
+        """Pre-fix: any -f that is neither .csv nor .json left label_infos unassigned and crashed with
+        NameError two lines later (#48 item 1)."""
+        bad = tmp_path / 'labels.txt'
+        bad.write_text('not metadata')
+        with pytest.raises(SystemExit) as e:
+            crop_runner.main(['-f', str(bad), '-s', str(tmp_path), '-o', str(tmp_path / 'crops')])
+        assert e.value.code not in (0, None)
+        printed = capsys.readouterr()
+        assert '.txt' in (printed.err + printed.out + str(e.value.code))
+
+    def test_extension_check_is_case_insensitive(self, crop_runner, tmp_path):
+        """labels.CSV is a CSV. Pre-fix the exact-match dispatch NameError'd on it."""
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, 'testpano0001')
+        csv_file = tmp_path / 'labels.CSV'
+        write_labels_csv(csv_file, [label_row()])
+        assert crop_runner.main(['-f', str(csv_file), '-s', str(store), '-o', str(out)]) == 0
+        assert os.path.exists(crop_path(out, 1, 1))
+
+    def test_csv_pano_ids_stay_strings(self, crop_runner, tmp_path):
+        """An all-numeric pano_id column otherwise infers int64 and pano_id[:2] raises TypeError — the
+        exact #46 intake bug DownloadRunner already fixed with a dtype pin."""
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, '1234567890')
+        csv_file = tmp_path / 'labels.csv'
+        write_labels_csv(csv_file, [label_row(pano_id='1234567890')])
+        assert crop_runner.main(['-f', str(csv_file), '-s', str(store), '-o', str(out)]) == 0
+        assert os.path.exists(crop_path(out, 1, 1))
+
+    def test_csv_missing_required_column_fails_loudly(self, crop_runner, tmp_path):
+        """A header typo must not surface as a KeyError deep in the crop loop."""
+        csv_file = tmp_path / 'labels.csv'
+        with open(csv_file, 'w', newline='') as f:
+            writer = csv.writer(f)
+            writer.writerow(['panorama', 'pano_x', 'pano_y', 'label_type_id', 'label_id'])
+            writer.writerow(['abc', 1, 2, 1, 1])
+        with pytest.raises((SystemExit, ValueError)) as e:
+            crop_runner.main(['-f', str(csv_file), '-s', str(tmp_path), '-o', str(tmp_path / 'crops')])
+        assert 'pano_id' in str(e.value)
+
+    def test_csv_dedupes_on_label_id(self, crop_runner, tmp_path):
+        rows = [label_row(label_id=7), label_row(label_id=7, pano_x=210)]
+        csv_file = tmp_path / 'labels.csv'
+        write_labels_csv(csv_file, rows)
+        labels = crop_runner.fetch_label_ids_csv(str(csv_file))
+        assert len(labels) == 1
+
+    def test_json_path_produces_crops(self, crop_runner, tmp_path):
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, 'testpano0001')
+        json_file = tmp_path / 'labels.json'
+        json_file.write_text(json.dumps([label_row()]))
+        assert crop_runner.main(['-f', str(json_file), '-s', str(store), '-o', str(out)]) == 0
+        assert os.path.exists(crop_path(out, 1, 1))
+
+    def test_json_dedupes_on_label_id(self, crop_runner):
+        labels = crop_runner.json_to_list([label_row(label_id=3), label_row(label_id=3)])
+        assert len(labels) == 1
+
+
+class TestServerFetch:
+
+    def test_session_is_hardened(self, crop_runner):
+        """Both schemes mounted (a redirect hop to http:// must not fall back to the retry-less default
+        adapter) and no env-proxy routing — the DownloadRunner #51 session shape."""
+        session = crop_runner.request_session()
+        try:
+            assert set(session.adapters) >= {'https://', 'http://'}
+            https_adapter = session.get_adapter('https://x')
+            assert https_adapter is session.get_adapter('http://x')
+            assert session.trust_env is False
+        finally:
+            session.close()
+
+    def test_fetch_passes_a_timeout(self, crop_runner, monkeypatch):
+        """Pre-fix session.get had no timeout at all: a hung server stalled the run indefinitely."""
+        captured = {}
+
+        class FakeResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return [label_row()]
+
+        class FakeSession:
+            trust_env = False
+
+            def get(self, url, **kwargs):
+                captured['url'] = url
+                captured.update(kwargs)
+                return FakeResponse()
+
+            def close(self):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                self.close()
+                return False
+
+        monkeypatch.setattr(crop_runner, 'request_session', lambda: FakeSession())
+        labels = crop_runner.fetch_cvMetadata_from_server('sidewalk-test.invalid')
+        assert len(labels) == 1
+        assert captured['url'] == 'https://sidewalk-test.invalid/adminapi/labels/cvMetadata'
+        assert captured.get('timeout') == (30, 600)
+
+    def test_fetch_failure_logs_the_actual_exception(self, crop_runner, monkeypatch, caplog):
+        """Pre-fix bug pair (#48 item 2): a ConnectionError wasn't caught at all, and the retry handler
+        logged the literal 'Retries: ' with the exception text dropped by a placeholder-less format()."""
+
+        class FakeSession:
+            trust_env = False
+
+            def get(self, url, **kwargs):
+                raise requests.exceptions.ConnectionError('boom-marker-1359')
+
+            def close(self):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                self.close()
+                return False
+
+        monkeypatch.setattr(crop_runner, 'request_session', lambda: FakeSession())
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(SystemExit) as e:
+                crop_runner.fetch_cvMetadata_from_server('sidewalk-test.invalid')
+        assert e.value.code == 1
+        assert 'boom-marker-1359' in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# predict_crop_size: behaviour pins so the extraction cannot drift the formula
+# ---------------------------------------------------------------------------
+
+class TestPredictCropSize:
+
+    @pytest.mark.parametrize('pano_y, pano_height, expected', [
+        (4677, 8192, 503.21326713898634),   # a real Seattle sample row
+        (5049, 8192, 1200.051484399708),    # near field, unclamped
+        (4096, 8192, 248.32906718298392),   # the horizon
+        (0, 8192, 50),                      # far field clamps to the floor
+        (6000, 8192, 1500),                 # near field clamps to the ceiling
+        (128, 256, 248.32906718298392),     # height-normalised: same relative y, same size
+    ])
+    def test_known_values(self, crop_runner, pano_y, pano_height, expected):
+        assert crop_runner.predict_crop_size(pano_y, pano_height) == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# The crop loop
+# ---------------------------------------------------------------------------
+
+class TestBulkExtractCrops:
+
+    def test_counts_reconcile(self, crop_runner, tmp_path):
+        """success + skipped_existing + missing_pano + errors must equal total. Pre-fix, already-existing
+        crops were counted nowhere, so no combination of the printed numbers summed to the input size
+        (#48 item 3)."""
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, 'testpano0001')
+        labels = [label_row(label_id=1, pano_x=150),
+                  label_row(label_id=2, pano_x=250),
+                  label_row(label_id=3, pano_id='gonepano0001')]
+        counts = crop_runner.bulk_extract_crops(labels, str(store), str(out))
+        assert counts == {'total': 3, 'success': 2, 'skipped_existing': 0, 'missing_pano': 1, 'errors': 0}
+
+    def test_rerun_skips_existing_and_still_reconciles(self, crop_runner, tmp_path):
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, 'testpano0001')
+        labels = [label_row(label_id=1, pano_x=150), label_row(label_id=2, pano_x=250)]
+        crop_runner.bulk_extract_crops(labels, str(store), str(out))
+        counts = crop_runner.bulk_extract_crops(labels, str(store), str(out))
+        assert counts == {'total': 2, 'success': 0, 'skipped_existing': 2, 'missing_pano': 0, 'errors': 0}
+
+    def test_a_corrupt_pano_does_not_kill_the_run(self, crop_runner, tmp_path, caplog):
+        """Pre-fix: nothing wrapped make_single_crop, so one truncated JPEG raised out of
+        bulk_extract_crops and lost the whole job (#48 item 4)."""
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        shard = store / 'ba'
+        shard.mkdir(parents=True)
+        (shard / 'badpano00001.jpg').write_bytes(b'this is not a jpeg')
+        put_pano(store, 'testpano0001')
+        labels = [label_row(label_id=1, pano_id='badpano00001'),
+                  label_row(label_id=2, pano_id='testpano0001')]
+        with caplog.at_level(logging.WARNING):
+            counts = crop_runner.bulk_extract_crops(labels, str(store), str(out))
+        assert counts['errors'] == 1
+        assert counts['success'] == 1
+        assert os.path.exists(crop_path(out, 1, 2))
+        assert 'badpano00001' in caplog.text
+
+    def test_a_malformed_row_is_an_error_not_a_crash(self, crop_runner, tmp_path):
+        """A row with a missing key or non-numeric coordinate is one bad label, not a dead run."""
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, 'testpano0001')
+        labels = [{'pano_id': 'testpano0001', 'label_id': 1},           # no coordinates at all
+                  label_row(label_id=2, pano_x='not-a-number'),
+                  label_row(label_id=3, pano_x=float('nan')),
+                  label_row(label_id=4)]
+        counts = crop_runner.bulk_extract_crops(labels, str(store), str(out))
+        assert counts['errors'] == 3
+        assert counts['success'] == 1
+        assert os.path.exists(crop_path(out, 1, 4))
+
+    def test_crops_are_written_atomically(self, crop_runner, tmp_path, monkeypatch):
+        """A crash mid-save must not leave a truncated .jpg that the next run's exists() check treats as
+        done — the downloaders' atomic_output_path contract, which the pre-fix direct save() lacked."""
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, 'testpano0001')
+
+        real_save = Image.Image.save
+
+        def failing_save(self, fp, *args, **kwargs):
+            real_save(self, fp, *args, **kwargs)  # write the bytes, then die before the rename
+            raise OSError('disk full marker')
+
+        monkeypatch.setattr(Image.Image, 'save', failing_save)
+        counts = crop_runner.bulk_extract_crops([label_row()], str(store), str(out))
+        assert counts['errors'] == 1
+        type_dir = out / '1'
+        leftovers = list(type_dir.iterdir()) if type_dir.exists() else []
+        assert leftovers == []  # neither the final .jpg nor a .part stub
+
+    def test_no_part_files_survive_a_successful_run(self, crop_runner, tmp_path):
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, 'testpano0001')
+        crop_runner.bulk_extract_crops([label_row()], str(store), str(out))
+        assert not [p for p in out.rglob('*.part')]
+
+    def test_pano_is_decoded_once_for_all_its_labels(self, crop_runner, tmp_path, monkeypatch):
+        """Discrimination for the decode-once change: a 16384x8192 pano is ~250 MB decoded, and the
+        pre-fix loop re-opened it once per label."""
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, 'testpano0001')
+        opened = []
+        real_open = Image.open
+
+        def counting_open(fp, *args, **kwargs):
+            opened.append(fp)
+            return real_open(fp, *args, **kwargs)
+
+        monkeypatch.setattr(crop_runner.Image, 'open', counting_open)
+        labels = [label_row(label_id=i, pano_x=100 + 40 * i) for i in range(1, 4)]
+        counts = crop_runner.bulk_extract_crops(labels, str(store), str(out))
+        assert counts['success'] == 3
+        assert len(opened) == 1
+
+    def test_crop_is_centred_on_the_label(self, crop_runner, tmp_path):
+        """A landmark square at the label position must land at the crop's centre."""
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, 'testpano0001', square_at=(200, INTERIOR_Y))
+        crop_runner.bulk_extract_crops([label_row()], str(store), str(out))
+        with Image.open(crop_path(out, 1, 1)) as crop:
+            w, h = crop.size
+            r, g, b = crop.getpixel((w // 2, h // 2))
+            corner = crop.getpixel((5, 5))
+        assert r + g + b < 150            # the landmark: near-black
+        assert sum(corner) > 600          # away from it: near-white
+
+
+class TestMarkLabel:
+
+    def test_marking_is_off_by_default(self, crop_runner, tmp_path):
+        """#48 item 5: every crop the tool ever produced carried a burned-in dot because MARK_LABEL
+        defaulted to True at module scope. Default must be clean pixels."""
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, 'testpano0001')
+        crop_runner.bulk_extract_crops([label_row()], str(store), str(out))
+        with Image.open(crop_path(out, 1, 1)) as crop:
+            w, h = crop.size
+            centre = crop.getpixel((w // 2, h // 2))
+        assert sum(centre) > 600  # untouched white pano
+
+    def test_mark_label_draws_a_centre_dot(self, crop_runner, tmp_path):
+        """Discrimination for the test above: the flag must actually do something, or 'off by default'
+        would also pass with marking deleted outright."""
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, 'testpano0001')
+        crop_runner.bulk_extract_crops([label_row()], str(store), str(out), mark_label=True)
+        with Image.open(crop_path(out, 1, 1)) as crop:
+            w, h = crop.size
+            centre = crop.getpixel((w // 2, h // 2))
+        assert sum(centre) < 600  # the dot
+
+    def test_marks_do_not_leak_between_labels_on_one_pano(self, crop_runner, tmp_path):
+        """Two nearby labels on one pano: each crop covers the other's position, so if marking drew on
+        the shared pano image (as the decode-once refactor would tempt), label 1's dot would appear
+        inside label 2's crop. It must not."""
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, 'testpano0001')
+        labels = [label_row(label_id=1, pano_x=200), label_row(label_id=2, pano_x=260)]
+        crop_runner.bulk_extract_crops(labels, str(store), str(out), mark_label=True)
+        with Image.open(crop_path(out, 1, 2)) as crop2:
+            w, h = crop2.size
+            # Label 1's pano position, expressed in crop 2's coordinates.
+            other = crop2.getpixel((w // 2 - 60, h // 2))
+            centre = crop2.getpixel((w // 2, h // 2))
+        assert sum(centre) < 600   # crop 2's own mark is present
+        assert sum(other) > 600    # crop 2 does not contain crop 1's mark
+
+
+# ---------------------------------------------------------------------------
+# main(): process-level wiring
+# ---------------------------------------------------------------------------
+
+class TestMain:
+
+    def test_end_to_end_csv_run(self, crop_runner, tmp_path, monkeypatch):
+        cwd = tmp_path / 'elsewhere'
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, 'testpano0001')
+        csv_file = tmp_path / 'labels.csv'
+        write_labels_csv(csv_file, [label_row()])
+
+        assert crop_runner.main(['-f', str(csv_file), '-s', str(store), '-o', str(out)]) == 0
+
+        assert os.path.exists(crop_path(out, 1, 1))
+        # crop.log lives with the crops, not in whatever CWD the process happened to have (the
+        # DownloadRunner #49 lesson: a Docker CWD dies with the container).
+        assert os.path.exists(os.path.join(str(out), 'crop.log'))
+        assert not os.path.exists(os.path.join(str(cwd), 'crop.log'))
+
+    def test_mark_label_flag_reaches_the_crop(self, crop_runner, tmp_path):
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, 'testpano0001')
+        csv_file = tmp_path / 'labels.csv'
+        write_labels_csv(csv_file, [label_row()])
+        crop_runner.main(['-f', str(csv_file), '-s', str(store), '-o', str(out), '--mark-label'])
+        with Image.open(crop_path(out, 1, 1)) as crop:
+            w, h = crop.size
+            assert sum(crop.getpixel((w // 2, h // 2))) < 600
+
+    def test_configure_logging_caps_urllib3(self, crop_runner, tmp_path):
+        crop_runner.configure_logging(str(tmp_path / 'crop.log'))
+        assert logging.getLogger('urllib3').level == logging.WARNING
+        assert logging.getLogger().handlers  # a handler was installed
+
+    def test_decompression_bomb_ceiling_covers_modern_panos(self, crop_runner, tmp_path, monkeypatch):
+        """A 16384x8192 pano is 134 MP — over Pillow's 89 MP default DecompressionBombWarning threshold.
+        The store is our own output, so the run must raise the ceiling rather than warn per pano (or
+        silently hard-fail at 2x the threshold)."""
+        monkeypatch.setattr(Image, 'MAX_IMAGE_PIXELS', 89478485)
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, 'testpano0001')
+        crop_runner.bulk_extract_crops([label_row()], str(store), str(out))
+        assert Image.MAX_IMAGE_PIXELS is None or Image.MAX_IMAGE_PIXELS >= 16384 * 8192

--- a/tests/test_crop_runner.py
+++ b/tests/test_crop_runner.py
@@ -14,6 +14,7 @@ import csv
 import json
 import logging
 import os
+import subprocess
 import sys
 
 import pytest
@@ -23,6 +24,8 @@ from PIL import Image
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
+
+RUNNER = os.path.join(REPO_ROOT, 'CropRunner.py')
 
 
 # ---------------------------------------------------------------------------
@@ -76,6 +79,25 @@ def put_pano(store_dir, pano_id, size=PANO_SIZE, color=(255, 255, 255), square_a
 
 def crop_path(out_dir, label_type_id, label_id):
     return os.path.join(str(out_dir), str(label_type_id), str(label_id) + '.jpg')
+
+
+def reconciles(counts):
+    """The #48 item-3 invariant: every input label lands in exactly one outcome bucket."""
+    return (counts['success'] + counts['skipped_existing'] + counts['missing_pano']
+            + counts['errors']) == counts['total']
+
+
+def truncate_pano(store_dir, pano_id, size=PANO_SIZE):
+    """Write a JPEG with a valid header and half its body — the production corruption mode.
+
+    Distinct from garbage bytes: this opens fine (Image.open only reads the header) and blows up later
+    inside crop()/load(), so it exercises the per-label handler rather than the per-pano one.
+    """
+    path = put_pano(store_dir, pano_id, size=size)
+    data = open(path, 'rb').read()
+    with open(path, 'wb') as f:
+        f.write(data[:len(data) // 2])
+    return path
 
 
 @pytest.fixture
@@ -193,13 +215,16 @@ class TestMetadataIntake:
         """The #46 intake bug, in its discriminating form: an all-numeric pano_id column with one blank
         cell infers float64 without a dtype pin, minting ids like '1234567890.0' whose shard paths quietly
         miss every real pano. The good row must still crop and the blank-id row must count as an error,
-        not walk off to a 'na/nan.jpg' path."""
+        not walk off to a 'na/nan.jpg' path — asserted on the counts, because 'the crop exists' alone
+        would also pass with the blank row silently filed as a missing pano."""
         store, out = tmp_path / 'store', tmp_path / 'crops'
         put_pano(store, '1234567890')
         csv_file = tmp_path / 'labels.csv'
         write_labels_csv(csv_file, [label_row(pano_id='1234567890', label_id=1),
                                     label_row(pano_id='', label_id=2)])
-        assert crop_runner.main(['-f', str(csv_file), '-s', str(store), '-o', str(out)]) == 0
+        labels = crop_runner.fetch_label_ids_csv(str(csv_file))
+        counts = crop_runner.bulk_extract_crops(labels, str(store), str(out))
+        assert counts == {'total': 2, 'success': 1, 'skipped_existing': 0, 'missing_pano': 0, 'errors': 1}
         assert os.path.exists(crop_path(out, 1, 1))
 
     def test_csv_missing_required_column_fails_loudly(self, crop_runner, tmp_path):
@@ -440,6 +465,136 @@ class TestBulkExtractCrops:
         assert r + g + b < 150            # the landmark: near-black
         assert sum(corner) > 600          # away from it: near-white
 
+    def test_a_whole_failed_pano_is_counted_per_label(self, crop_runner, tmp_path):
+        """The grouping refactor moved accounting from per-row to per-pano, so both whole-pano outcomes
+        now add len(labels). Every other test here puts exactly one label on the failing pano, which
+        cannot tell `+= len(labels)` from `+= 1`; this one can, and it is the reconciliation invariant
+        (#48 item 3) that would break."""
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, 'goodpano0001')
+        shard = store / 'ba'
+        shard.mkdir(parents=True, exist_ok=True)
+        (shard / 'badpano00001.jpg').write_bytes(b'this is not a jpeg')
+        labels = ([label_row(pano_id='gonepano0001', label_id=i) for i in (1, 2, 3)]
+                  + [label_row(pano_id='badpano00001', label_id=i) for i in (4, 5)]
+                  + [label_row(pano_id='goodpano0001', label_id=6)])
+        counts = crop_runner.bulk_extract_crops(labels, str(store), str(out))
+        assert counts == {'total': 6, 'success': 1, 'skipped_existing': 0, 'missing_pano': 3, 'errors': 2}
+        assert reconciles(counts)
+
+    def test_a_truncated_pano_is_one_error_per_label(self, crop_runner, tmp_path, caplog):
+        """The corruption #48 actually describes: a JPEG whose header is intact and whose body is cut
+        short. Image.open succeeds on it (it only reads the header), so this fails in crop()/load() and
+        is caught by the per-label handler — a different branch from the garbage-bytes case above, which
+        never reaches it."""
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        truncate_pano(store, 'cutpano00001')
+        put_pano(store, 'goodpano0001')
+        labels = [label_row(pano_id='cutpano00001', label_id=1),
+                  label_row(pano_id='cutpano00001', label_id=2),
+                  label_row(pano_id='goodpano0001', label_id=3)]
+        with caplog.at_level(logging.WARNING):
+            counts = crop_runner.bulk_extract_crops(labels, str(store), str(out))
+        assert counts == {'total': 3, 'success': 1, 'skipped_existing': 0, 'missing_pano': 0, 'errors': 2}
+        assert 'Failed to crop label' in caplog.text
+        # A failed crop must leave nothing behind: the crop file is the resume marker, so a stub here
+        # would be read as done on the next run.
+        assert not os.path.exists(crop_path(out, 1, 1))
+
+    def test_a_non_finite_coordinate_is_a_row_error_not_a_crop_error(self, crop_runner, tmp_path, caplog):
+        """Discrimination for the isfinite guard: without it a NaN coordinate still lands in `errors`,
+        just via a crop failure instead, so the counts alone cannot tell the two apart. The
+        classification is what matters — a row that never had a usable position is bad metadata, not a
+        bad pano, and the operator reads the log to tell those apart."""
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, 'testpano0001')
+        with caplog.at_level(logging.WARNING):
+            counts = crop_runner.bulk_extract_crops([label_row(label_id=1, pano_y=float('nan'))],
+                                                    str(store), str(out))
+        assert counts['errors'] == 1
+        assert 'Skipping malformed label row' in caplog.text
+        assert 'Failed to crop label' not in caplog.text
+
+    def test_a_blank_pano_id_string_is_an_error(self, crop_runner, tmp_path):
+        """A JSON payload can carry '' (or a padded id) where the CSV intake would carry NaN. It must be
+        a counted error, not a missing pano: '' shards to the store root and would be reported forever
+        as an image we are still waiting on."""
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        store.mkdir(parents=True)
+        counts = crop_runner.bulk_extract_crops(
+            [label_row(pano_id='', label_id=1), label_row(pano_id='   ', label_id=2)], str(store), str(out))
+        assert counts == {'total': 2, 'success': 0, 'skipped_existing': 0, 'missing_pano': 0, 'errors': 2}
+
+    def test_an_unusable_output_directory_is_one_error_not_a_dead_run(self, crop_runner, tmp_path):
+        """os.makedirs sat outside the try, so an OSError on the output side — a full store, a read-only
+        mount, an sshfs drop, the conditions atomic_output_path itself cites — raised straight out of
+        bulk_extract_crops. That is #48 item 4 again on the write side: the remaining labels never ran
+        and the counts dict never came back."""
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, 'testpano0001')
+        out.mkdir(parents=True)
+        (out / '1').write_text('a FILE where the label-type DIR should go')
+        labels = [label_row(label_id=1, label_type_id=1), label_row(label_id=2, label_type_id=2)]
+        counts = crop_runner.bulk_extract_crops(labels, str(store), str(out))
+        assert counts == {'total': 2, 'success': 1, 'skipped_existing': 0, 'missing_pano': 0, 'errors': 1}
+        assert os.path.exists(crop_path(out, 2, 2))
+
+    def test_the_label_type_directory_is_made_once_per_type(self, crop_runner, tmp_path, monkeypatch):
+        """exist_ok=True still costs a stat, and the loop ran it per label. Over sshfs that is a network
+        round trip for each of a city's ~400k labels."""
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, 'testpano0001')
+        out.mkdir(parents=True)  # so os.makedirs never recurses to create the parent and inflate the count
+        made = []
+        real_makedirs = os.makedirs
+
+        def counting_makedirs(path, *args, **kwargs):
+            made.append(path)
+            return real_makedirs(path, *args, **kwargs)
+
+        monkeypatch.setattr(crop_runner.os, 'makedirs', counting_makedirs)
+        labels = [label_row(label_id=1, label_type_id=1, pano_x=140),
+                  label_row(label_id=2, label_type_id=1, pano_x=180),
+                  label_row(label_id=3, label_type_id=2, pano_x=220)]
+        counts = crop_runner.bulk_extract_crops(labels, str(store), str(out))
+        assert counts['success'] == 3
+        assert made == [str(out / '1'), str(out / '2')]  # one per label type, not one per label
+
+    def test_the_shared_pano_is_closed_when_its_labels_are_done(self, crop_runner, tmp_path, monkeypatch):
+        """The other half of decode-once: holding one ~250 MB decoded pano is the point, holding every
+        pano in a city is a leak. Nothing pinned the close, so `with pano:` could be dropped silently."""
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, 'testpano0001')
+        put_pano(store, 'otherpano001')
+        opened, closed = [], []
+        real_open, real_close = Image.open, Image.Image.close
+
+        def recording_open(fp, *args, **kwargs):
+            img = real_open(fp, *args, **kwargs)
+            opened.append(img)
+            return img
+
+        def recording_close(self):
+            closed.append(self)
+            return real_close(self)
+
+        monkeypatch.setattr(crop_runner.Image, 'open', recording_open)
+        monkeypatch.setattr(Image.Image, 'close', recording_close)
+        crop_runner.bulk_extract_crops([label_row(pano_id='testpano0001', label_id=1),
+                                        label_row(pano_id='otherpano001', label_id=2)], str(store), str(out))
+        assert len(opened) == 2
+        assert all(any(c is img for c in closed) for img in opened)
+
+    def test_bulk_extract_does_not_mutate_the_pil_global(self, crop_runner, tmp_path, monkeypatch):
+        """The decompression-bomb ceiling is process-level policy and belongs in main(). This module is
+        importable now — that is the whole point of #52.1 — so a library caller's PIL globals are not
+        ours to rewrite as a side effect of extracting some crops."""
+        monkeypatch.setattr(Image, 'MAX_IMAGE_PIXELS', 89478485)
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, 'testpano0001')
+        crop_runner.bulk_extract_crops([label_row()], str(store), str(out))
+        assert Image.MAX_IMAGE_PIXELS == 89478485
+
 
 class TestMarkLabel:
 
@@ -522,10 +677,47 @@ class TestMain:
 
     def test_decompression_bomb_ceiling_covers_modern_panos(self, crop_runner, tmp_path, monkeypatch):
         """A 16384x8192 pano is 134 MP — over Pillow's 89 MP default DecompressionBombWarning threshold.
-        The store is our own output, so the run must raise the ceiling rather than warn per pano (or
-        silently hard-fail at 2x the threshold)."""
+        The store is our own output, so a run must raise the ceiling rather than warn per pano (or
+        silently hard-fail at 2x the threshold). Driven through main(), which is where process-level
+        policy belongs; see test_bulk_extract_does_not_mutate_the_pil_global for the other half."""
         monkeypatch.setattr(Image, 'MAX_IMAGE_PIXELS', 89478485)
         store, out = tmp_path / 'store', tmp_path / 'crops'
         put_pano(store, 'testpano0001')
-        crop_runner.bulk_extract_crops([label_row()], str(store), str(out))
+        csv_file = tmp_path / 'labels.csv'
+        write_labels_csv(csv_file, [label_row()])
+        crop_runner.main(['-f', str(csv_file), '-s', str(store), '-o', str(out)])
         assert Image.MAX_IMAGE_PIXELS is None or Image.MAX_IMAGE_PIXELS >= 16384 * 8192
+
+    def test_errored_labels_make_the_exit_code_nonzero(self, crop_runner, tmp_path):
+        """A run that cropped nothing at all exited 0, so nothing downstream of cron could tell it from
+        a clean one. `errors` is the signal: it only ever counts things that should not have happened."""
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        truncate_pano(store, 'cutpano00001')
+        csv_file = tmp_path / 'labels.csv'
+        write_labels_csv(csv_file, [label_row(pano_id='cutpano00001')])
+        assert crop_runner.main(['-f', str(csv_file), '-s', str(store), '-o', str(out)]) == 1
+
+    def test_missing_panos_alone_still_exit_zero(self, crop_runner, tmp_path):
+        """Discrimination for the test above, and the reason the exit code keys on `errors` rather than
+        on 'did every label produce a crop': the pano store is scraped separately and legitimately lags
+        the label list, so labels waiting on an undownloaded pano are the normal state of a fresh city,
+        not a failure."""
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        store.mkdir(parents=True)
+        csv_file = tmp_path / 'labels.csv'
+        write_labels_csv(csv_file, [label_row(pano_id='gonepano0001')])
+        assert crop_runner.main(['-f', str(csv_file), '-s', str(store), '-o', str(out)]) == 0
+
+    def test_running_as_a_script_crops(self, crop_runner, tmp_path):
+        """`python3 CropRunner.py ...` end to end, in a real subprocess. Every other test here calls
+        main(argv) in-process, which never executes the __main__ guard itself — so a typo in that one
+        line would ship green (test_download_runner drives the real script through runpy for the same
+        reason). No network: -f plus a synthetic store."""
+        store, out = tmp_path / 'store', tmp_path / 'crops'
+        put_pano(store, 'testpano0001')
+        csv_file = tmp_path / 'labels.csv'
+        write_labels_csv(csv_file, [label_row()])
+        proc = subprocess.run([sys.executable, RUNNER, '-f', str(csv_file), '-s', str(store),
+                               '-o', str(out)], capture_output=True, text=True, timeout=300)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert os.path.exists(crop_path(out, 1, 1))


### PR DESCRIPTION
## What

First PR of the cropper work package (test scaffold -> #48 -> #47 -> the #32/#54 studies). CropRunner was the last untested production module (#57): it ran argparse and its whole flow at module scope, so no test could even import it. This PR restructures it to the #52.1 shape and fixes the #48 cluster, test-first.

**RED commit** (`99b6e69`): 38 new tests, 38 of 38 fail on the pre-fix code — 37 error inside `import CropRunner` (module-scope argparse), 1 fails on the side-effect assertion.
**GREEN commit** (`c9f0af0`): the refactor + fixes; all 38 pass, full suite 395 pass / 24 Windows skips.

### The seams (mirrors DownloadRunner, #52.1)

`build_parser()` / `configure_logging()` / `run()` / `main(argv=None)` + `__main__` guard; import is side-effect-free (pinned by the same test shape as `test_download_runner.py`).

### The #48 cluster

1. **Unknown `-f` extension** exits with a message naming the file (was `NameError`); the check is case-insensitive. Bare `-d` is now a parse error (`nargs='?'` used to accept it and request `https://None/adminapi/...`).
2. **Dropped exception text**: the fetch now catches `RequestException` (ConnectionError was previously uncaught entirely) and logs the real exception — `'Retries: '.format(e)` had no placeholder.
3. **Totals reconcile**: `bulk_extract_crops` returns a counts dict with `success + skipped_existing + missing_pano + errors == total`, including on resumed runs; the dead `no_metadata_fail` counter is gone.
4. **One corrupt JPEG is one error, not a dead run**: per-pano/per-label error handling; failed crops retry next run (the crop file is its own resume marker).
5. **`MARK_LABEL` is now `--mark-label`, default OFF** — every crop the tool ever produced had a (128,0,0) dot burned over the feature of interest.

### Hazards found while pinning

- **#46's bug class in the CSV intake**: `pano_id` is dtype-pinned to `str` with required-column guards. The discriminating case is an all-numeric column with one blank cell — float64 inference mints `1234567890.0` ids whose shard paths quietly miss every pano.
- **Decode-once**: each pano is opened once for all its labels (a 16384x8192 pano is ~250 MB decoded; the old loop re-decoded per label). Marks draw on the crop, never the shared pano — a test pins that label A''s dot cannot leak into label B''s crop.
- **Atomic writes** via `downloaders/common.py::atomic_output_path` (a truncated crop used to become a permanent fake success via the exists() resume check).
- Session hardening (both schemes, `trust_env=False`, `(30, 600)` timeouts — there was previously no timeout at all); rotating `crop.log` next to the crops instead of DEBUG `basicConfig` into the CWD at import; decompression-bomb ceiling raised to cover 134 MP panos; dead `cElementTree` import removed.

### Deliberately unchanged

- `predict_crop_size` — pinned at 6 points (both clamps, the horizon, a real Seattle row, height normalization) precisely so this refactor cannot drift it. The formula replacement is the #32/#54 study work.
- Crop geometry — #47 (seam wrap, y clamp, dims reconciliation) is the next PR, on top of this one.

## Review round 2 (`6cda975`)

A deep review of `c9f0af0` found two real defects and a set of unpinned claims; all are fixed in a follow-up commit. 11 more tests (49 in the file), and every fix verified by killing its own mutant.

- **`os.makedirs` sat outside the per-label `try`** — #48 item 4 again on the write side. An OSError from a full store, a read-only mount, or an sshfs drop raised straight out of `bulk_extract_crops`: the remaining labels never ran and the counts dict never came back, contradicting the function's own "nothing here is fatal". It also ran once per *label*; `exist_ok` still costs a stat, so over sshfs that was a round trip for each of a city's ~400k labels. Now inside the `try` and memoized per label type.
- **`with pano:` closed nothing.** `Image.__exit__` has been a no-op since Pillow 11, while `requirements.txt` still allows the Pillow where it did close — so releasing the decode-once buffer depended on which Pillow happened to be installed. Now an explicit `try/finally: pano.close()`.
- An empty or whitespace `pano_id` (a JSON payload's `''` where CSV gives `nan`) was filed as a *missing pano* rather than a bad row; now stripped and counted as an error.
- `main()` exits **1 when any label errored** — deliberately not on `missing_pano`, which is the normal state of a city whose scrape is still catching up.
- The decompression-bomb ceiling moves to `main()` as `raise_decompression_bomb_ceiling()`: since #52.1 this module is importable, so rewriting a PIL global as a side effect of extracting crops reaches into another program (it also leaked across test modules in the suite).
- `REQUIRED_LABEL_COLUMNS` claimed both intakes enforce it; only the CSV one does. `main()`'s `exist_ok` comment invited concurrent invocations the fixed `.part` path doesn't support.

Newly pinned (each verified against its mutant): whole-pano outcomes counted **per label** — every earlier test put exactly one label on the failing pano, so `+= len(labels)` and `+= 1` were indistinguishable and the reconciliation invariant was unpinned; a **truncated** JPEG (valid header, half a body — the corruption #48 describes), which opens fine and fails in the per-label handler, a different branch from the garbage-bytes case; a non-finite coordinate classified as a bad row rather than a bad pano; the shared pano closed; and `python3 CropRunner.py ...` run as a real subprocess, since calling `main(argv)` in-process never executes the `__main__` guard.

**Docs**, which the first round left stale: `CLAUDE.md` still described `MARK_LABEL` as a module constant and both runners as having no `__main__` guard (already wrong for DownloadRunner since #52); README's usage line advertised a `-c` flag CropRunner has never had, plus the `nargs='?'` brackets this PR removes. README now also warns that **every crop produced before `--mark-label` carries a burned-in dot over the feature of interest** — re-crop rather than reuse an old set.

## Verification

- **405 pass / 24 skip** locally (Windows; skips are `posix_only` + streetlevel-not-installed, both covered by ubuntu CI). 49 tests in `tests/test_crop_runner.py`.
- **Mutation check, round 1: 9/9 killed** — mark-label default flipped on; mark drawn on shared pano; atomic save removed; skipped counter dropped; `Image.open` unguarded; dtype pin removed; timeout removed; exponent drifted to −1.2; extension check made case-sensitive. The decode-once guard counts `Image.open` calls directly, so it discriminates by construction.
- **Mutation check, round 2: 15/15 killed** — the round-1 survivors the review found (per-pano counting ×2, the isfinite guard, the pano close) plus one per new fix: `makedirs` reverted outside the `try`, mkdir de-duplication removed, empty-`pano_id` guard deleted, `pano_id` no longer stripped, exit code always 0, exit code also firing on missing panos, ceiling never raised, ceiling raised inside `bulk_extract_crops`, atomic write dropped, `__main__` guard broken.
- CLI smoke test on `samples/labeldata.csv`: first run 3 extracted / 3 missing / exit 0; resumed run 3 skipped / exit 0.

Issues: #48, #57 (CropRunner rows), #46 / #52 (cropper halves)

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)
Review round 2 by claude-opus-5[1m].
