### PR TITLE
Fix the pre-noon-UTC failure in the log-analyzer staleness test

### DIFF
--- a/tests/test_log_analyzer.py
+++ b/tests/test_log_analyzer.py
@@ -8,7 +8,7 @@ import argparse
 import ast
 import importlib.util
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -50,8 +50,25 @@ def write_log(path, rows, header=True):
 
 
 def days_ago(n):
-    """A timestamp n days back, fixed at midday so a run never lands on the previous calendar date."""
-    return datetime.now().replace(hour=12, minute=0, second=0, microsecond=0) - timedelta(days=n)
+    """A timestamp exactly n days before the clock analyze_city measures against, so
+    `(now - ts).days == n` at every time of day.
+
+    It must be that clock: analyze_city computes staleness from `datetime.now(timezone.utc)`, and
+    this used to anchor to *local* midday instead. On a UTC runner that made the elapsed time
+    n-1 days plus a fraction for the whole morning, and `.days` floors -- so every CI run before
+    12:00 UTC saw one day fewer than the test asked for, while every afternoon run passed.
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=n)
+
+
+def test_days_ago_agrees_with_the_clock_the_analyzer_measures_against():
+    """Pins the helper's contract in the same order production uses it: the row is written first,
+    the analyzer reads its clock second. Anchoring days_ago to any fixed hour instead reintroduces
+    the morning-only failure, because `.days` floors."""
+    for n in (0, 1, 3, 10, 400):
+        ts = days_ago(n)
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        assert (now - ts).days == n, f'days_ago({n}) did not read back as {n} days old'
 
 
 def recent_rows(count=7, **overrides):


### PR DESCRIPTION
`tests/test_log_analyzer.py::test_stale_log_is_critical` fails on `master` and on every open PR, and has been failing every CI run that starts before 12:00 UTC:

```
AssertionError: assert '10 days old' in 'Last log entry is 9 days old (last run: 2026-08-02)'
```

**It is not a flake.** `analyze_city` measures staleness as `(datetime.now(timezone.utc) - last_ts).days`, while the `days_ago` test helper anchored its timestamp to *local* midday. On a UTC runner that leaves `n-1` days plus a morning's worth of hours between them, and `.days` floors — so the row reads one day younger than the test asked for.

The boundary is visible in the run history: every failure ran at **03:29–03:57 UTC**, every green run at **13:27–21:02 UTC**.

| helper | timestamp for `days_ago(10)` | `.days` seen at 03:59 UTC |
|---|---|---|
| before | local midday − 10 d | **9** ❌ |
| after | `utcnow` − 10 d | **10** ✅ |

The helper now subtracts from the same clock `analyze_city` reads. Elapsed time becomes exactly *n* days plus the microseconds between the two calls — *n* at any hour, and never *n−1*, since the analyzer's `now` is always the later of the two. The midday anchor existed to keep a row off the previous calendar date; subtracting whole days from the current instant does that too.

Also adds `test_days_ago_agrees_with_the_clock_the_analyzer_measures_against`, which pins the contract in production's order (row written first, clock read second), so a future fixed-hour anchor fails immediately instead of only before noon.

**This blocks #80, #81 and #82**, none of which touch the analyzer — worth merging first so their CI reflects their own changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])