### PR TITLE
Close out #52: a real enum, a log column that stops lying, and a legacy path that could blacklist live panos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,10 @@ python3 DownloadRunner.py <fqdn> <storage-dir> [-c <csv>] [--all-panos] [--skip-
     [--max-runtime MINUTES] [--min-depth-runtime MINUTES] [--max-depth-requests N]
 
 # Cropper (exits 1 if any label errored; missing/untrusted panos alone are not an error)
-python3 CropRunner.py (-d <fqdn> | -f <metadata.csv|.json>) [-s <pano-dir>] [-o <crop-dir>] [--mark-label]
+python3 CropRunner.py (-d <fqdn> | -f <metadata.csv|.json>) -s <pano-dir> -o <crop-dir> [--mark-label]
+
+# flag_panos JSON -> CSV, for one city (one-off tool; see flag_panos/README.md)
+python3 flag_panos/json_to_csv.py --city <city> [--dir <dir>]
 
 # Log analyzer (needs PS_SFTP_HOST + PS_SFTP_BASE; see README's "Log analyzer")
 python3 log_analyzer/analyze.py [--no-download] [--city <city_id>] [--stale-days N]
@@ -67,6 +70,7 @@ CI (`.github/workflows/tests.yml`) runs the suite on Ubuntu 22.04 / Python 3.10,
 
 **downloaders/** — per-source download logic; `download_pano()` dispatches on `pano_info['source']`.
 - `gsv.py` stitches 512×512 tiles from Google's undocumented `cbk?output=tile` endpoint into one equirectangular JPEG. Determines a working zoom level (5 preferred, falling back to 3; a fully-black tile at both means no imagery), fans the tiles out concurrently via `aiohttp` with `backoff` retries, pastes them into a blank canvas sized per the server's width/height, and upscales zoom-3 panos with LANCZOS.
+  - **`fallback_success` is "the stitch was upscaled", not "zoom == 3".** `download_single_pano` returns it when `_dims_at_zoom(w, h, zoom) != final_im_dimension`, which is exactly when `_stitch_tiles` had to LANCZOS the frame up to the reported dims. Those two rules disagree on the panos that matter: an old four-level pano (3328×1664) has max zoom 3, so zoom 3 *is* its native resolution and nothing was lost. Two tests hold that split apart and both kill a `zoom == 3` implementation. Nothing returned this verdict at all until #52, so `log.csv` column 8 was a constant `0` for every run before it — and `log_analyzer` sums that column into `daily_success`, so it was adding a permanent zero.
 - `gsv.py` also owns the **depth phase** (`download_depth_maps`), which fetches depth via the `streetlevel` library's photometa call — one metadata request per unresolved pano.
 - `mapillary.py` resolves `thumb_original_url` via the Graph API and downloads it. Requires `MAPILLARY_ACCESS_TOKEN`.
 
@@ -121,6 +125,14 @@ plus the referenced HF dataset must reproduce every number in `reports/`.
 
 ## Things that are easy to get wrong
 
+- **`print` and `logging` are two channels with different jobs — do not "unify" them.** `print` is the
+  operator-facing run narrative and the warnings **cron mails**; `logging` is the durable per-item detail in
+  `scrape.log` / `crop.log`. **A warning that matters goes to both**, which is the depth phase's pattern
+  (`logging.error(...)` then `print(...)`), because stdout is how someone hears about it tonight and the log
+  is what is still there next week. #52 item 6 read the mixture as inconsistency; it is mostly deliberate,
+  README leans on a `WARNING` reaching cron mail, and ~15 tests assert on `capsys`. A print-to-logging sweep
+  would break all three. The one real violation — `filter_supported_sources` warning on stdout only — is
+  fixed; `caplog` assertions now sit beside its `capsys` ones so a revert fails.
 - **`log.csv` is positional and headerless.** 18 comma-separated fields, blank-padded. Fields 2–6 are an XML-metadata stub kept at fixed values purely so column positions never shift (that endpoint died in 2022). Blank ≠ 0: blank means the phase never finished. The full table is in README's "Ops notes"; `LOG_CSV_FIELD_COUNT` and `log_analyzer/analyze.py`'s `LOG_COLUMNS` must move together, and a test asserts they do.
 - **The depth failure count is not an alert signal.** It includes `unavailable`, a permanent and expected outcome, so early backfill runs show large, entirely normal failure numbers. The success/failure/unavailable split goes to stdout and `scrape.log`.
 - **Depth artifacts are un-mirrored on write.** `streetlevel`'s decoder x-mirrors the payload relative to the pano JPEG; `_write_depth_artifact` flips it back (#58), so a consumer can index the stored array with `pano_x`/`pano_y` scaled by width/height, no correction needed. `tests/test_streetlevel_api.py` pins the decode's end-to-end column order so a streetlevel change fails CI rather than silently re-mirroring new artifacts.

--- a/CropRunner.py
+++ b/CropRunner.py
@@ -120,10 +120,13 @@ def raise_decompression_bomb_ceiling():
 def build_parser():
     parser = argparse.ArgumentParser()
     group_parser = parser.add_mutually_exclusive_group(required=True)
-    group_parser.add_argument('-d', help='sidewalk_server_domain (preferred over metadata_file) - FDQN of SidewalkWebpage server to fetch label list from, i.e. sidewalk-columbus.cs.washington.edu')
+    group_parser.add_argument('-d', help='sidewalk_server_domain (preferred over metadata_file) - FQDN of SidewalkWebpage server to fetch label list from, i.e. sidewalk-columbus.cs.washington.edu')
     group_parser.add_argument('-f', help='metadata_file - path to file containing label_ids and their properties. It may be CSV or JSON. i.e. samples/labeldata.csv')
-    parser.add_argument('-s', default='/tmp/download_dest/', help='pano_storage_directory - path to directory containing panoramas downloaded using DownloadRunner.py. default=/tmp/download_dest/')
-    parser.add_argument('-o', default='/crops/', help='crop_output_directory - path to location for saving the crops. default=/crops/')
+    # Required, with no defaults (#52 item 6). -o used to default to the filesystem root and -s to the
+    # Docker container's scratch path - and the container runs DownloadRunner, not this script. A forgotten
+    # flag should name itself, not quietly put an ML training corpus somewhere nobody thinks to look.
+    parser.add_argument('-s', required=True, help='pano_storage_directory - path to directory containing panoramas downloaded using DownloadRunner.py')
+    parser.add_argument('-o', required=True, help='crop_output_directory - path to location for saving the crops')
     parser.add_argument('--mark-label', action='store_true', help='Draw a dot at the label position in every crop. Debugging aid - deliberately OFF by default, because these crops are ML training data and a synthetic marker painted over the feature of interest is exactly what a model would learn instead of the feature.')
     return parser
 
@@ -217,7 +220,7 @@ def fetch_cvMetadata_from_file(metadata_json_path):
     return json_to_list(json_meta)
 
 
-def fetch_cvMetadata_from_server(server_fdqn):
+def fetch_cvMetadata_from_server(server_fqdn):
     """
     Fetch cvMetadata over HTTP and transform it into a list of dicts, one per label.
 
@@ -225,7 +228,7 @@ def fetch_cvMetadata_from_server(server_fdqn):
     text and exits 1. (The old handler pair missed ConnectionError entirely and logged a placeholder-less
     'Retries: '.format(e) that dropped the exception, #48.)
     """
-    url = 'https://' + server_fdqn + '/adminapi/labels/cvMetadata'
+    url = 'https://' + server_fqdn + '/adminapi/labels/cvMetadata'
     try:
         print("Getting metadata from web server")
         with request_session() as session:
@@ -261,7 +264,7 @@ def _metadata_dims(row):
     return int(width), int(height)
 
 
-def load_label_metadata(sidewalk_server_fdqn, label_metadata_file):
+def load_label_metadata(sidewalk_server_fqdn, label_metadata_file):
     """Dispatch to the right intake for -d / -f, with a clear error for an unrecognized -f extension
     (which used to fall through to a NameError, #48)."""
     if label_metadata_file is not None:
@@ -272,7 +275,7 @@ def load_label_metadata(sidewalk_server_fdqn, label_metadata_file):
             return fetch_cvMetadata_from_file(label_metadata_file)
         sys.exit("CropRunner: unrecognized metadata file extension %r (expected .csv or .json): %s"
                  % (extension, label_metadata_file))
-    return fetch_cvMetadata_from_server(sidewalk_server_fdqn)
+    return fetch_cvMetadata_from_server(sidewalk_server_fqdn)
 
 
 def _reference_crop_size(ref_y_offset):

--- a/DownloadRunner.py
+++ b/DownloadRunner.py
@@ -38,7 +38,7 @@ def _reservation_minutes(value):
 
 def build_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument('d', help='sidewalk_server_domain - FDQN of SidewalkWebpage server to fetch pano list from, i.e. sidewalk-columbus.cs.washington.edu')
+    parser.add_argument('d', help='sidewalk_server_domain - FQDN of SidewalkWebpage server to fetch pano list from, i.e. sidewalk-columbus.cs.washington.edu')
     parser.add_argument('s', help='storage_path - location to store scraped panos')
     parser.add_argument('-c', nargs='?', default=None, help='csv_path - location of csv from which to read pano metadata')
     parser.add_argument('--all-panos', action='store_true', help='Download images for all panos that users visited, even if no labels were added on them. Does not affect depth, which always covers every pano.')
@@ -218,15 +218,21 @@ def filter_supported_sources(pano_infos):
     # unsupported source - hence 'known' rather than reusing 'supported' in the loop below.
     known = {'gsv', 'mapillary'}
     supported = {'gsv'}
+    # Both warnings go to stdout AND to scrape.log, the depth phase's pattern (#52 item 6). stdout is what
+    # cron mails, which is how an operator finds out tonight; scrape.log is what is still there next week
+    # when someone asks why a city's Mapillary panos never arrived. Either channel alone loses one of those.
     if source_counts.get('mapillary'):
         if mapillary.is_token_set():
             supported.add('mapillary')
         else:
+            logging.warning("%d Mapillary panos skipped - set %s to download them",
+                            source_counts['mapillary'], mapillary.TOKEN_ENV_VAR)
             print("WARNING: %d Mapillary panos skipped — set %s to download them"
                   % (source_counts['mapillary'], mapillary.TOKEN_ENV_VAR))
 
     for source, count in source_counts.items():
         if source not in known:
+            logging.warning("%d panos with unsupported source %r skipped", count, source)
             print("WARNING: %d panos with unsupported source %r skipped" % (count, source))
 
     return [p for p in pano_infos if p.get('source') in supported]

--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ Panos with any other `source` value are skipped with a warning.
 
 Usage:
 ```python
-python CropRunner.py [-h] (-d D | -f F) [-s S] [-o O] [--mark-label]
+python CropRunner.py [-h] (-d D | -f F) -s S -o O [--mark-label]
 ```
 * To fetch label metadata from webserver or a file, use respectively (mutually exclusive, required):
   * ``-d <project-sidewalk-url>``
   * ``-f <path-to-label-metadata-file>`` (`.csv` or `.json`)
-* ``-s <path-to-panoramas-dir>`` (optional). Specify if using a different directory containing panoramas. Panoramas are used to crop the labels.
-* ``-o <path-of-crop-dir>`` (optional). Specify if want to set a different directory for crops to be stored. `crop.log` is written here too.
+* ``-s <path-to-panoramas-dir>`` (**required**). The directory containing panoramas downloaded by `DownloadRunner.py`; they are what the labels are cropped out of.
+* ``-o <path-of-crop-dir>`` (**required**). Where crops are written. `crop.log` is written here too. Both paths used to have defaults — `/crops/` and `/tmp/download_dest/` — which were the filesystem root and a Docker-only scratch path respectively, so forgetting one wrote an ML training corpus somewhere nobody would look for it. Since [#52](https://github.com/ProjectSidewalk/sidewalk-panorama-tools/issues/52) a missing flag is an argparse error naming it.
 * ``--mark-label`` (optional, debugging aid). Draws a dot at the label position in every crop. Off by default — the crops are ML training data, and a synthetic marker painted over the feature of interest is exactly what a model would learn instead of the feature.
 
 Crops are **3:2**, centered on the label, sized by **crop sizing rule v2** and written to `<crop-dir>/<label_type_id>/<label_id>.jpg` at `min(window, 1440)` px wide — never upscaled. The window is an *angle*: the camera-to-label distance formula is evaluated in the 6656-px pano height its constants were fit on, scaled back to the pano's own pixels, scaled up ×2.5 and clamped to 8°–90°. Before v2 it was fed native pixels, so the same ramp asked for a window 1.86–4.09× different depending only on the panorama's resolution, and the largest panoramas got the tightest crops — see [the rule v2 report](reports/2026-08-19-crop-sizing-v2.md). Which rule cut a store is recorded in `<crop-dir>/crop_rule.json`; **check it before training on a directory.** Existing crops are never re-cut, so a store cropped before v2 keeps its square v1 crops and silently accretes 3:2 ones alongside them — the run warns when it notices, but deleting the store is the only way to get one geometry. Crop windows wrap across the equirectangular seam (the left and right image edges are the same place in the world) and shift to stay inside the image at the top and bottom, so a crop never contains synthetic black padding. In a six-city census of 438,410 labels, 1.52% cross the seam; before this was fixed every one of those crops carried a black bar.
@@ -294,7 +294,7 @@ The phase is serial — one metadata request in flight at a time, unlike the ima
   | 5 | metadata total processed | count of image-eligible panos (stub) |
   | 6 | metadata phase duration | effectively `0` (stub) |
   | 7 | image successes | |
-  | 8 | image fallback successes | downloaded, but at a fallback resolution |
+  | 8 | image fallback successes | downloaded, but at a fallback resolution — only zoom 3 was available for a frame whose reported dimensions need zoom 5, so the stitch was upscaled to reach them. Real imagery, materially less of it. **Not** simply "downloaded at zoom 3": an old pano whose own max zoom is 3 is at its native resolution and counts in field 7. Was a constant `0` before [#52](https://github.com/ProjectSidewalk/sidewalk-panorama-tools/issues/52) because nothing ever returned the verdict, so runs before that show every fallback inside field 7 |
   | 9 | image failures | includes prior runs' permanent failures, seeded from `pano_id_log.csv`; a transient failure is not ledgered, so it is counted again if it fails again next run |
   | 10 | image skipped | includes panos already downloaded on previous runs, seeded likewise |
   | 11 | image total processed | sum of fields 7–10 |

--- a/downloaders/common.py
+++ b/downloaders/common.py
@@ -1,16 +1,27 @@
 import contextlib
+import enum
 import os
 
 
-class Enum(object):
-    def __init__(self, tuplelist):
-        self.tuplelist = tuplelist
+class DownloadResult(enum.Enum):
+    """What a downloader decided about one pano. See downloaders/__init__.py for the ledger contract.
 
-    def __getattr__(self, name):
-        return self.tuplelist.index(name)
+    enum.Enum, not IntEnum, and deliberately (#52 item 2). This was a hand-rolled class whose members were
+    indices into a tuple, which made `skipped` == 0 and therefore FALSY - one `if result:` anywhere would
+    have silently misclassified an already-downloaded pano - and turned a typo'd member into a ValueError
+    raised from inside __getattr__, so hasattr() raised instead of answering and the message never named
+    the attribute. Nothing compares these to ints or does arithmetic on them (every call site is `==`
+    against a symbol), so there is no reason to keep them int-like and every reason not to.
+    """
 
-
-DownloadResult = Enum(('skipped', 'success', 'fallback_success', 'failure'))
+    skipped = 'skipped'
+    success = 'success'
+    #: The pano was downloaded, but only zoom 3 was available while its reported dimensions need zoom 5, so
+    #: the stitch was LANCZOS-upscaled to reach them. Real imagery, materially less of it. This is NOT
+    #: simply `zoom == 3`: an old pano whose max zoom IS 3 is downloaded at its native resolution and is a
+    #: plain success. See gsv.download_single_pano for the predicate, and log.csv column 8.
+    fallback_success = 'fallback_success'
+    failure = 'failure'
 
 
 @contextlib.contextmanager

--- a/downloaders/gsv.py
+++ b/downloaders/gsv.py
@@ -36,11 +36,6 @@ except ImportError:
     # leave it behind). Don't take the whole scraper down over a throttle that defaults to off anyway.
     depth_min_request_interval = 0.0
 
-try:
-    from xml.etree import cElementTree as ET
-except ImportError:
-    from xml.etree import ElementTree as ET
-
 from .common import DownloadResult, atomic_output_path
 
 
@@ -338,65 +333,44 @@ def download_single_pano(storage_path, pano_info):
 
     final_image_width = int(pano_dims[0]) if pano_dims[0] is not None else None
     final_image_height = int(pano_dims[1]) if pano_dims[1] is not None else None
-    zoom = None
 
     # Session scoped to the zoom/dimension probes below; the tile fan-out uses its own aiohttp session. This
     # runs once per pano, so leaving it unclosed would pile up connection pools until GC (#51).
     with _request_session() as session:
-        # Check XML metadata for image width/height max zoom if its downloaded.
-        xml_metadata_path = os.path.join(destination_dir, pano_id + ".xml")
-        if os.path.isfile(xml_metadata_path):
-            print(xml_metadata_path)
-            with open(xml_metadata_path, 'rb') as pano_xml:
-                try:
-                    tree = ET.parse(pano_xml)
-                    root = tree.getroot()
+        # There is no legacy-XML path here any more (#52 items 3/4/5). It read a `<pano_id>.xml` for dims and
+        # zoom; #39 removed the downloader that wrote those (cbk?output=xml died in 2022), so the files on the
+        # store are frozen 2022 metadata. It could only ever run for a pano with an .xml and NO .jpg - the
+        # skip check above returns first - which is 1 of the 1,025 .xml files sampled across dc, columbus-oh,
+        # amsterdam and newberg-or. On that one pano it did harm: a declared num_zoom_levels was trusted over
+        # the probe and test-fetched, and a black tile returned DownloadResult.failure, which is PERMANENT
+        # under the #41 ledger. So stale 2022 metadata could blacklist a pano Google still serves.
 
-                    # Get the number of zoom levels.
-                    for child in root:
-                        if child.tag == 'data_properties':
-                            zoom = int(child.attrib['num_zoom_levels'])
-                            if final_image_width is None:
-                                final_image_width = int(child.attrib['width'])
-                            if final_image_height is None:
-                                final_image_height = int(child.attrib['height'])
-
-                    # If there is no zoom in the XML, then we skip this and try some zoom levels below.
-                    if zoom is not None:
-                        # Check if the image exists (occasionally we will have XML but no JPG).
-                        test_url = f'{base_url}&zoom={zoom}&x=0&y=0&panoid={pano_id}'
-                        test_request = _get_response(test_url, session, stream=True)
-                        test_tile = Image.open(test_request)
-                        if test_tile.convert("L").getextrema() == (0, 0):
-                            return DownloadResult.failure
-                except Exception:
-                    pass
-
-        # If we did not find image width/height from API or XML, then set download to failure.
+        # Without dims we cannot size the tile grid. Permanent, hence failure: /adminapi/panos is the only
+        # source for them, so re-attempting the same row tomorrow asks the same question again.
         if final_image_width is None or final_image_height is None:
             return DownloadResult.failure
 
-        # If we did not find a zoom level in the XML above, then try a couple zoom level options here.
-        if zoom is None:
-            url_zoom_3 = f'{base_url}&zoom=3&x=0&y=0&panoid={pano_id}'
-            url_zoom_5 = f'{base_url}&zoom=5&x=0&y=0&panoid={pano_id}'
+        # The probe is now the only thing that picks a zoom, so it is unconditional - it used to sit behind
+        # `if zoom is None:` because the legacy XML could have set one already.
+        url_zoom_3 = f'{base_url}&zoom=3&x=0&y=0&panoid={pano_id}'
+        url_zoom_5 = f'{base_url}&zoom=5&x=0&y=0&panoid={pano_id}'
 
-            req_zoom_3 = _get_response(url_zoom_3, session, stream=True)
-            im_zoom_3 = Image.open(req_zoom_3)
-            req_zoom_5 = _get_response(url_zoom_5, session, stream=True)
-            im_zoom_5 = Image.open(req_zoom_5)
+        req_zoom_3 = _get_response(url_zoom_3, session, stream=True)
+        im_zoom_3 = Image.open(req_zoom_3)
+        req_zoom_5 = _get_response(url_zoom_5, session, stream=True)
+        im_zoom_5 = Image.open(req_zoom_5)
 
-            # In some cases (e.g., old GSV images), we don't have zoom level 5, so Google returns a transparent
-            # image. This means we need to set the zoom level to 3. Google also returns a transparent image if
-            # there is no imagery. So check at both zoom levels. How to check:
-            # http://stackoverflow.com/questions/14041562/python-pil-detect-if-an-image-is-completely-black-or-white
-            if im_zoom_5.convert("L").getextrema() != (0, 0):
-                zoom = 5
-            elif im_zoom_3.convert("L").getextrema() != (0, 0):
-                zoom = 3
-            else:
-                # Can't determine zoom.
-                return DownloadResult.failure
+        # In some cases (e.g., old GSV images), we don't have zoom level 5, so Google returns a transparent
+        # image. This means we need to set the zoom level to 3. Google also returns a transparent image if
+        # there is no imagery. So check at both zoom levels. How to check:
+        # http://stackoverflow.com/questions/14041562/python-pil-detect-if-an-image-is-completely-black-or-white
+        if im_zoom_5.convert("L").getextrema() != (0, 0):
+            zoom = 5
+        elif im_zoom_3.convert("L").getextrema() != (0, 0):
+            zoom = 3
+        else:
+            # Can't determine zoom.
+            return DownloadResult.failure
 
     final_im_dimension = (final_image_width, final_image_height)
 

--- a/downloaders/gsv.py
+++ b/downloaders/gsv.py
@@ -423,12 +423,23 @@ def download_single_pano(storage_path, pano_info):
                         "stitching at reduced resolution - check the CBK request parameters (#73)",
                         pano_id, degraded, len(ok), TILE_SIZE)
 
-    image = _stitch_tiles(ok, _dims_at_zoom(final_image_width, final_image_height, zoom), final_im_dimension)
+    zoom_dims = _dims_at_zoom(final_image_width, final_image_height, zoom)
+    image = _stitch_tiles(ok, zoom_dims, final_im_dimension)
     _reject_mostly_black_stitch(image, pano_id, zoom)
     # atomic_output_path, not a direct save: an image on disk IS the resume marker, so a mid-write crash
     # would otherwise leave a truncated .jpg that every later run reports as a completed download.
     with atomic_output_path(out_image_name) as tmp_path:
         image.save(tmp_path, 'jpeg')
+
+    # log.csv column 8 (#52 item 2). The test is whether the grid we could actually download covers the
+    # pano's reported frame; if it doesn't, _stitch_tiles LANCZOS-upscaled to reach it, and the JPEG on disk
+    # holds less imagery than its dimensions advertise. Deliberately NOT `zoom == 3`: an old four-level pano
+    # (3328x1664) has max zoom 3, so zoom 3 IS its native resolution and nothing was lost - calling that
+    # degraded would put a permanent false positive in front of ops on the oldest imagery in the store.
+    if zoom_dims != final_im_dimension:
+        logging.info("IMAGEDOWNLOAD: pano %s: only zoom %s was available for a %dx%d frame; stitched %dx%d "
+                     "and upscaled", pano_id, zoom, final_image_width, final_image_height, *zoom_dims)
+        return DownloadResult.fallback_success
     return DownloadResult.success
 
 

--- a/flag_panos/json_to_csv.py
+++ b/flag_panos/json_to_csv.py
@@ -1,16 +1,72 @@
+"""Convert the flag_panos web tool's JSON output to CSV, for one city.
+
+The tool (index.html / index.js, see README.md) writes `<city>_pano_image_data.json` and
+`<city>_unretrievable_panos.json`. This turns whichever of them exist into CSVs beside them.
+
+The module imports with no side effects (the #52.1 contract the two runners honour): build_parser() and
+main(argv) are the seams, and `python3 flag_panos/json_to_csv.py --city <city>` behaviour lives under the
+__main__ guard. It used to do all of its work at module scope against `CITY = 'amsterdam'` and the CWD, so
+using it on another city meant editing the file, importing it ran it, and a missing input surfaced as a bare
+traceback naming one filename and neither the city nor the directory it had looked in (#52 item 6).
+"""
+
+import argparse
+import os
+import sys
+
 import pandas as pd
 
-CITY = 'amsterdam'
-# JSON_TO_CONVERT = f'{CITY}_unretrievable_panos.json'
-# CSV_OUTPUT = f'{CITY}_unretrievable_panos.csv'
+# The two artifacts the web tool produces. Suffixes, not whole names, because the city is a parameter now.
+INPUT_SUFFIXES = ('_pano_image_data', '_unretrievable_panos')
 
-JSON_TO_CSV_MAP = {
-    f'{CITY}_pano_image_data.json': f'{CITY}_pano_image_data.csv',
-    f'{CITY}_unretrievable_panos.json': f'{CITY}_unretrievable_panos.csv'
-}
 
-for json_file in JSON_TO_CSV_MAP.keys():
-    with open(json_file, encoding='utf-8') as f:
-        df = pd.read_json(f)
+def build_parser():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument('--city', required=True,
+                        help="City id the flag_panos filenames are prefixed with, i.e. amsterdam")
+    parser.add_argument('--dir', default='.',
+                        help='Directory holding the JSON files; the CSVs are written beside them. default=.')
+    return parser
 
-    df.to_csv(JSON_TO_CSV_MAP[json_file], encoding='utf-8', index=False)
+
+def convert(directory, city):
+    """Convert every INPUT_SUFFIXES file present for `city`; return the list of CSV paths written.
+
+    Absent inputs are skipped rather than fatal - the web tool does not always produce both, and failing the
+    whole run over the missing one would make this unusable in the case it exists for. main() is what decides
+    that finding NOTHING is an error.
+    """
+    written = []
+    for suffix in INPUT_SUFFIXES:
+        json_path = os.path.join(directory, '%s%s.json' % (city, suffix))
+        if not os.path.isfile(json_path):
+            continue
+        csv_path = os.path.join(directory, '%s%s.csv' % (city, suffix))
+        with open(json_path, encoding='utf-8') as f:
+            df = pd.read_json(f)
+        # index=False: pandas would otherwise write a nameless leading index column, shifting every field by
+        # one for anything reading the result positionally.
+        df.to_csv(csv_path, encoding='utf-8', index=False)
+        written.append(csv_path)
+    return written
+
+
+def main(argv=None):
+    """:return: 0, or 1 if the city had none of the expected inputs in the given directory."""
+    args = build_parser().parse_args(argv)
+
+    written = convert(args.dir, args.city)
+    if not written:
+        print("json_to_csv: no flag_panos JSON for city %r in %s (looked for %s)"
+              % (args.city, os.path.abspath(args.dir),
+                 ', '.join('%s%s.json' % (args.city, s) for s in INPUT_SUFFIXES)),
+              file=sys.stderr)
+        return 1
+
+    for path in written:
+        print("Wrote %s" % path)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_crop_runner.py
+++ b/tests/test_crop_runner.py
@@ -194,15 +194,27 @@ class TestParser:
         assert e.value.code == 2
 
     def test_defaults(self, crop_runner):
-        args = crop_runner.build_parser().parse_args(['-d', 'sidewalk-test.invalid'])
-        assert args.s == '/tmp/download_dest/'
-        assert args.o == '/crops/'
+        args = crop_runner.build_parser().parse_args(
+            ['-d', 'sidewalk-test.invalid', '-s', '/panos', '-o', '/out'])
         assert args.mark_label is False
+
+    def test_the_pano_and_crop_directories_are_required(self, crop_runner):
+        """#52 item 6. -o defaulted to the filesystem ROOT (needs sudo on Linux, lands on the system drive
+        on Windows) and -s to /tmp/download_dest/, a path that only means anything inside the Docker
+        container - which runs DownloadRunner, not this script. A forgotten flag should name itself rather
+        than quietly write an ML training corpus somewhere nobody will look for it."""
+        for argv in (['-d', 'x.invalid'],
+                     ['-d', 'x.invalid', '-s', '/panos'],
+                     ['-d', 'x.invalid', '-o', '/out']):
+            with pytest.raises(SystemExit) as e:
+                crop_runner.build_parser().parse_args(argv)
+            assert e.value.code == 2
 
     def test_mark_label_is_a_flag(self, crop_runner):
         """The old MARK_LABEL=True module constant burned a dot into every crop ever produced (#48);
         marking must be an explicit opt-in."""
-        args = crop_runner.build_parser().parse_args(['-d', 'x.invalid', '--mark-label'])
+        args = crop_runner.build_parser().parse_args(
+            ['-d', 'x.invalid', '-s', '/panos', '-o', '/out', '--mark-label'])
         assert args.mark_label is True
 
 

--- a/tests/test_download_runner.py
+++ b/tests/test_download_runner.py
@@ -708,6 +708,49 @@ class TestRetrySemantics:
         assert attempts == []
 
 
+class TestFallbackResolutionReachesTheLog:
+    """log.csv column 8, which README documents as "downloaded, but at a fallback resolution".
+
+    `fallback_success` was defined in the enum and threaded through this loop's counters, but no downloader
+    ever returned it - so the column has been a hard 0 for every run ever recorded, and
+    log_analyzer/analyze.py sums that zero into daily_success. gsv.download_single_pano now returns it when
+    the stitch had to be upscaled to reach the pano's reported dims; these pin the loop's half of that.
+    """
+
+    def fallback_download_pano(self, attempts):
+        def fake(storage_path, pano_info):
+            attempts.append(pano_info['pano_id'])
+            return downloaders.DownloadResult.fallback_success
+        return fake
+
+    def test_a_fallback_is_counted_in_its_own_column_not_as_a_plain_success(self, monkeypatch, tmp_path):
+        storage = tmp_path / 'storage'
+        storage.mkdir()
+        monkeypatch.setattr(DownloadRunner, 'download_pano', self.fallback_download_pano([]))
+
+        success, fallback, fail, skipped, total = DownloadRunner.download_panorama_images(
+            str(storage), gsv_pano_infos()[:1])
+
+        assert (success, fallback, fail, skipped, total) == (0, 1, 0, 0, 1)
+
+    def test_a_fallback_is_ledgered_downloaded_1_and_never_reattempted(self, monkeypatch, tmp_path):
+        """It is real imagery on disk, just less of it - so it is terminal like any other success. Ledgering
+        it 0 would re-download it against --max-runtime every night, forever."""
+        storage = tmp_path / 'storage'
+        storage.mkdir()
+        attempts = []
+        monkeypatch.setattr(DownloadRunner, 'download_pano', self.fallback_download_pano(attempts))
+        DownloadRunner.download_panorama_images(str(storage), gsv_pano_infos()[:1])
+
+        with open(storage / 'pano_id_log.csv') as f:
+            assert f.read().strip().splitlines()[1:] == ['%s,1' % GSV_PANO_IDS[0]]
+
+        monkeypatch.setattr(DownloadRunner, 'download_pano', recording_download_pano(attempts))
+        DownloadRunner.download_panorama_images(str(storage), gsv_pano_infos()[:1])
+
+        assert attempts == [GSV_PANO_IDS[0]], "a ledgered fallback must not be re-attempted"
+
+
 class TestSourceOrdering:
     """#40: grouping by source put every GSV pano ahead of every Mapillary one, so a city whose GSV backlog
     exceeds --max-runtime starved Mapillary indefinitely - zero progress, and invisibly, since unattempted

--- a/tests/test_download_runner.py
+++ b/tests/test_download_runner.py
@@ -770,24 +770,29 @@ class TestSourceOrdering:
 
         assert kept == self.mixed_panos()
 
-    def test_filter_without_token_still_drops_mapillary_with_one_warning(self, monkeypatch, capsys):
+    def test_filter_without_token_still_drops_mapillary_with_one_warning(self, monkeypatch, capsys, caplog):
         monkeypatch.delenv(downloaders.mapillary.TOKEN_ENV_VAR, raising=False)
 
-        kept = DownloadRunner.filter_supported_sources(self.mixed_panos())
+        with caplog.at_level(logging.WARNING):
+            kept = DownloadRunner.filter_supported_sources(self.mixed_panos())
 
         assert [p['pano_id'] for p in kept] == ['gsvPanoIdAAAAAAAAAAAAA', 'gsvPanoIdBBBBBBBBBBBBB']
         out = capsys.readouterr().out
         assert out.count('WARNING') == 1
         assert '2 Mapillary panos skipped' in out
+        # And durably, in scrape.log: stdout is cron mail, which nobody has after the fact (#52 item 6).
+        assert '2 Mapillary panos skipped' in caplog.text
 
-    def test_unsupported_source_warning_still_prints_a_count(self, monkeypatch, capsys):
+    def test_unsupported_source_warning_still_prints_a_count(self, monkeypatch, capsys, caplog):
         monkeypatch.setenv(downloaders.mapillary.TOKEN_ENV_VAR, 'test-token')
         panos = self.mixed_panos() + [{'pano_id': 'testPanoIdOtherAAAAAAA', 'source': 'bing'},
                                       {'pano_id': 'testPanoIdOtherBBBBBBB', 'source': 'bing'}]
 
-        DownloadRunner.filter_supported_sources(panos)
+        with caplog.at_level(logging.WARNING):
+            DownloadRunner.filter_supported_sources(panos)
 
         assert "2 panos with unsupported source 'bing' skipped" in capsys.readouterr().out
+        assert "2 panos with unsupported source 'bing' skipped" in caplog.text
 
     def test_budget_exhaustion_does_not_starve_mapillary(self, monkeypatch, tmp_path):
         """End to end with a fake monotonic clock: 4 interleaved panos, one simulated minute each, and a

--- a/tests/test_gsv_stitcher.py
+++ b/tests/test_gsv_stitcher.py
@@ -483,7 +483,9 @@ class TestDownloadSinglePano:
 
         result = gsv.download_single_pano(str(tmp_path), self.pano_info(width=8192, height=4096))
 
-        assert result == DownloadResult.success
+        # fallback_success, not success: this pano's own dims need zoom 4, so the zoom-3 stitch is upscaled
+        # to reach them (#52 item 2, log.csv column 8). TestFallbackResolutionIsReported owns that split.
+        assert result == DownloadResult.fallback_success
         assert {(x, y) for x, y, _ in requested} == {(x, y) for x in range(8) for y in range(4)}
         assert all('zoom=3' in url for _, _, url in requested)
         with Image.open(tmp_path / 'st' / 'stitchPanoAAAAAAAAAAAA.jpg') as image:
@@ -506,6 +508,20 @@ class TestDownloadSinglePano:
         with Image.open(tmp_path / 'st' / 'stitchPanoAAAAAAAAAAAA.jpg') as image:
             assert image.size == (3328, 1664)
             assert gsv._black_fraction(image) == 0.0
+
+    def test_a_fallback_and_a_native_zoom3_are_not_the_same_outcome(self, tmp_path, monkeypatch):
+        """Guards the pair below from drifting apart: same picked zoom, same stubs, different verdict, and
+        the only thing that differs is whether the pano's own dims need a zoom the download could not get."""
+        stub_probe(monkeypatch, pick_zoom=3)
+        stub_tiles(monkeypatch, lambda tile: (tile[0], tile[1], jpeg_bytes(RED)))
+
+        native = gsv.download_single_pano(str(tmp_path), self.pano_info('nativeZoom3AAAAAAAAAAA',
+                                                                       width=3328, height=1664))
+        upscaled = gsv.download_single_pano(str(tmp_path), self.pano_info('upscaledZoom3AAAAAAAAA',
+                                                                         width=8192, height=4096))
+
+        assert native == DownloadResult.success
+        assert upscaled == DownloadResult.fallback_success
 
     def test_degraded_tile_bodies_still_fill_the_whole_frame(self, tmp_path, monkeypatch, caplog):
         """The regression this review caught, end to end: every body arrives at half size (cbk's load-shed

--- a/tests/test_gsv_stitcher.py
+++ b/tests/test_gsv_stitcher.py
@@ -523,6 +523,51 @@ class TestDownloadSinglePano:
         assert native == DownloadResult.success
         assert upscaled == DownloadResult.fallback_success
 
+    def test_a_legacy_xml_beside_the_pano_is_ignored(self, tmp_path, monkeypatch):
+        """#52 items 3/4/5. download_single_pano used to read a legacy `<pano_id>.xml` for dims and zoom.
+        Its producer was removed in #39 (the cbk?output=xml endpoint died in 2022), but the files are still
+        on the store - sampled across dc/columbus-oh/amsterdam/newberg-or, 1,025 of them, of which exactly
+        ONE had no .jpg beside it. That one pano is the only case the block could ever run, because the
+        "image already exists -> skipped" check returns first.
+
+        The block is gone; dims come from /adminapi/panos and the zoom comes from the probe. This pins that
+        a stray .xml cannot change the outcome - including a malformed one, which the deleted code swallowed
+        with a bare `except Exception: pass` so it was indistinguishable from no file at all."""
+        shard = tmp_path / 'st'
+        shard.mkdir()
+        (shard / 'stitchPanoAAAAAAAAAAAA.xml').write_text('<not-even-xml')
+        stub_probe(monkeypatch, pick_zoom=5)
+        stub_tiles(monkeypatch, lambda tile: (tile[0], tile[1], jpeg_bytes(RED)))
+
+        result = gsv.download_single_pano(str(tmp_path), self.pano_info())
+
+        assert result == DownloadResult.success
+        with Image.open(shard / 'stitchPanoAAAAAAAAAAAA.jpg') as image:
+            assert image.size == (1024, 512)
+            assert gsv._black_fraction(image) == 0.0
+
+    def test_a_wellformed_legacy_xml_cannot_veto_a_pano_google_still_serves(self, tmp_path, monkeypatch):
+        """The discriminating half, and the reason deleting the block is a fix rather than a tidy-up.
+
+        A well-formed legacy XML declaring `num_zoom_levels` made the old code trust that zoom over the
+        probe, then test-fetch one tile at it - and return DownloadResult.failure if that tile came back
+        black. failure is PERMANENT under the #41 ledger: the pano is written downloaded=0 and never
+        re-attempted. So a stale 2022 XML could blacklist a pano that Google serves perfectly well today,
+        which is precisely the pano this block only ever runs on (an .xml with no .jpg beside it).
+
+        With the block gone the probe answers, finds zoom 5, and the pano downloads at native resolution."""
+        shard = tmp_path / 'st'
+        shard.mkdir()
+        (shard / 'stitchPanoAAAAAAAAAAAA.xml').write_text(
+            '<panorama><data_properties num_zoom_levels="3" width="8192" height="4096"/></panorama>')
+        stub_probe(monkeypatch, pick_zoom=5)
+        stub_tiles(monkeypatch, lambda tile: (tile[0], tile[1], jpeg_bytes(RED)))
+
+        result = gsv.download_single_pano(str(tmp_path), self.pano_info(width=8192, height=4096))
+
+        assert result == DownloadResult.success
+        assert (shard / 'stitchPanoAAAAAAAAAAAA.jpg').is_file()
+
     def test_degraded_tile_bodies_still_fill_the_whole_frame(self, tmp_path, monkeypatch, caplog):
         """The regression this review caught, end to end: every body arrives at half size (cbk's load-shed
         rendering). The saved pano must still be full-frame imagery at the reported dims, and the run must

--- a/tests/test_image_downloaders.py
+++ b/tests/test_image_downloaders.py
@@ -82,6 +82,36 @@ class TestAtomicOutputPath:
         assert os.stat(final).st_mode & 0o777 == 0o664
 
 
+class TestDownloadResultIsARealEnum:
+    """#52 item 2. `DownloadResult` was a hand-rolled class whose members were tuple indices, which cost
+    three things the stdlib gives away: `skipped` was 0 and therefore FALSY (so `if result:` anywhere
+    misclassifies it), a typo'd member raised `ValueError` from inside `__getattr__` rather than
+    `AttributeError` (so `hasattr` RAISED instead of returning False, and the message never named the
+    attribute), and members printed into logs as bare ints."""
+
+    def test_no_member_is_falsy(self):
+        """The one that could have silently misclassified a pano: 'skipped' was index 0."""
+        for member in DownloadResult:
+            assert member, f"{member!r} is falsy; `if result:` would misread it"
+
+    def test_a_typo_raises_attribute_error_naming_the_attribute(self):
+        with pytest.raises(AttributeError, match='sucess'):
+            DownloadResult.sucess
+
+    def test_hasattr_answers_instead_of_raising(self):
+        assert hasattr(DownloadResult, 'success')
+        assert not hasattr(DownloadResult, 'sucess')
+
+    def test_members_identify_themselves_in_logs(self):
+        """A log line carrying a bare 2 says nothing; the point of the enum is that the name travels."""
+        assert 'fallback_success' in repr(DownloadResult.fallback_success)
+
+    def test_the_four_outcomes_are_distinct(self):
+        members = [DownloadResult.skipped, DownloadResult.success,
+                   DownloadResult.fallback_success, DownloadResult.failure]
+        assert len(set(members)) == 4
+
+
 class FakeResponse:
     def __init__(self, status_code=200, payload=None, body=None, chunks=None):
         self.status_code = status_code

--- a/tests/test_json_to_csv.py
+++ b/tests/test_json_to_csv.py
@@ -1,0 +1,137 @@
+"""Tests for flag_panos/json_to_csv.py (#52 item 6, last bullet).
+
+The script converts the flag_panos web tool's JSON output to CSV. It was 16 lines with `CITY = 'amsterdam'`
+hardcoded, two commented-out config lines, no argparse, no main() and no error handling - so it did all its
+work at import, against whatever the CWD happened to be, and a missing input surfaced as a bare traceback.
+
+These pin the same #52.1 contract the two runners already honour: importing the module does nothing, the
+seams are build_parser() / main(argv), and the failure mode names the file.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+SCRIPT = os.path.join(REPO_ROOT, 'flag_panos', 'json_to_csv.py')
+
+
+@pytest.fixture
+def json_to_csv():
+    from flag_panos import json_to_csv as module
+    return module
+
+
+def write_inputs(directory, city, image_data=True, unretrievable=True):
+    """Write whichever of the two flag_panos outputs the test wants, and return their stems."""
+    written = []
+    if image_data:
+        path = directory / ('%s_pano_image_data.json' % city)
+        path.write_text(json.dumps([{'pano_id': 'abc', 'width': 16384},
+                                    {'pano_id': 'def', 'width': 13312}]))
+        written.append(path)
+    if unretrievable:
+        path = directory / ('%s_unretrievable_panos.json' % city)
+        path.write_text(json.dumps([{'pano_id': 'ghi'}]))
+        written.append(path)
+    return written
+
+
+class TestTheModuleImportsWithNoSideEffects:
+    """The #52.1 contract. This module used to run its whole conversion at import against the CWD, so
+    importing it - which the test suite now does - either crashed or silently wrote files."""
+
+    def test_importing_does_not_read_or_write_anything(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        import importlib
+
+        from flag_panos import json_to_csv as module
+        importlib.reload(module)
+
+        assert list(tmp_path.iterdir()) == []
+
+    def test_the_seams_exist(self, json_to_csv):
+        assert callable(json_to_csv.build_parser)
+        assert callable(json_to_csv.main)
+
+
+class TestTheParser:
+    def test_city_is_required(self, json_to_csv):
+        with pytest.raises(SystemExit) as e:
+            json_to_csv.build_parser().parse_args([])
+        assert e.value.code == 2
+
+    def test_the_directory_defaults_to_the_cwd(self, json_to_csv):
+        args = json_to_csv.build_parser().parse_args(['--city', 'amsterdam'])
+        assert args.dir == '.'
+
+    def test_any_city_works_not_just_amsterdam(self, json_to_csv):
+        """`CITY = 'amsterdam'` was a module constant, so using it on another city meant editing the file."""
+        args = json_to_csv.build_parser().parse_args(['--city', 'seattle'])
+        assert args.city == 'seattle'
+
+
+class TestConversion:
+    def test_both_files_round_trip(self, json_to_csv, tmp_path, capsys):
+        write_inputs(tmp_path, 'amsterdam')
+
+        assert json_to_csv.main(['--city', 'amsterdam', '--dir', str(tmp_path)]) == 0
+
+        image_csv = tmp_path / 'amsterdam_pano_image_data.csv'
+        assert image_csv.is_file()
+        rows = image_csv.read_text().strip().splitlines()
+        assert rows[0].split(',') == ['pano_id', 'width']
+        assert len(rows) == 3, 'header plus two records'
+        assert (tmp_path / 'amsterdam_unretrievable_panos.csv').is_file()
+
+    def test_a_city_with_only_one_of_the_two_still_converts(self, json_to_csv, tmp_path):
+        """The web tool does not always produce both, and failing the whole run over the absent one would
+        make the tool unusable in exactly the case it was written for."""
+        write_inputs(tmp_path, 'seattle', unretrievable=False)
+
+        assert json_to_csv.main(['--city', 'seattle', '--dir', str(tmp_path)]) == 0
+
+        assert (tmp_path / 'seattle_pano_image_data.csv').is_file()
+        assert not (tmp_path / 'seattle_unretrievable_panos.csv').exists()
+
+    def test_no_inputs_at_all_names_what_it_looked_for(self, json_to_csv, tmp_path, capsys):
+        """The old script raised a bare FileNotFoundError from inside a loop, naming one file and never
+        saying which city or directory it had been asked about."""
+        code = json_to_csv.main(['--city', 'nowhere', '--dir', str(tmp_path)])
+
+        assert code == 1
+        message = capsys.readouterr().err
+        assert 'nowhere' in message
+        assert str(tmp_path) in message
+
+    def test_the_index_column_is_not_written(self, json_to_csv, tmp_path):
+        """pandas writes a nameless index column by default, which would shift every field by one for any
+        consumer reading positionally."""
+        write_inputs(tmp_path, 'amsterdam', unretrievable=False)
+        json_to_csv.main(['--city', 'amsterdam', '--dir', str(tmp_path)])
+
+        header = (tmp_path / 'amsterdam_pano_image_data.csv').read_text().splitlines()[0]
+        assert header == 'pano_id,width'
+
+
+class TestRunAsAScript:
+    def test_the_main_guard_runs_the_conversion(self, tmp_path):
+        write_inputs(tmp_path, 'amsterdam', unretrievable=False)
+
+        result = subprocess.run([sys.executable, SCRIPT, '--city', 'amsterdam', '--dir', str(tmp_path)],
+                                capture_output=True, text=True, timeout=120)
+
+        assert result.returncode == 0, result.stderr
+        assert (tmp_path / 'amsterdam_pano_image_data.csv').is_file()
+
+    def test_a_missing_city_exits_nonzero_for_a_shell_caller(self, tmp_path):
+        result = subprocess.run([sys.executable, SCRIPT, '--city', 'nowhere', '--dir', str(tmp_path)],
+                                capture_output=True, text=True, timeout=120)
+
+        assert result.returncode == 1


### PR DESCRIPTION
Closes #52.

## What was actually left

#52 is a six-item cleanup filed during a code-quality review. About half of it had already been done by other PRs and the issue was never updated, so the first job was checking each item against the code rather than against the issue text:

| Item | Status on arrival |
|---|---|
| 1. no `main()` / `__main__` guard, module-scope globals | already done — both runners have the `build_parser()` / `configure_logging()` / `run(...)` / `main(argv)` shape, and `run_scraper_and_log_results` takes `storage_location` as a parameter |
| 3. `ET` import in `CropRunner.py`, `aiohttp.web` in `gsv.py`, the #41 retry branch, unused `except ImportError as e` | already done |
| 4. four bare `print`s in `DownloadRunner.py`, per-label `print(pano_width, pano_height)` | already done |
| 6. eagerly-formatted `logging` calls | already done — every `logging.*` call is lazy `%`-style |

What remained is items 2, 5, the two `gsv.py` leftovers from item 4, and item 6. Two of those turned out not to be cosmetic.

## The log column that was lying

`fallback_success` was in the enum and threaded through the image loop's counters, but **no downloader has ever returned it**. So `log.csv` column 8 has been a hard `0` for every run ever recorded, `log_analyzer` sums that zero into `daily_success`, and README describes the column as "downloaded, but at a fallback resolution" — which was simply untrue. The zoom-3 path never stopped existing; it stopped saying so.

**The predicate is not `zoom == 3`.** What matters is whether the grid we could actually download covers the pano's reported frame — `_dims_at_zoom(w, h, zoom) != final_im_dimension`, i.e. exactly when `_stitch_tiles` had to LANCZOS the frame up. The two rules disagree on the panos most likely to be inspected:

| pano | zoom | `_dims_at_zoom` | | result |
|---|---|---|---|---|
| 3328×1664 (max zoom 3) | 3 | (3328, 1664) | native | `success` |
| 8192×4096 | 3 | (4096, 2048) | upscaled | `fallback_success` |
| 16384×8192 | 3 | (4096, 2048) | upscaled | `fallback_success` |
| 16384×8192 | 5 | (16384, 8192) | native | `success` |

A `zoom == 3` implementation would report a permanent false positive on the oldest imagery in the store. Both mutants are killed: `if zoom == 3` fails 2 tests (including the **pre-existing** native-zoom test), `if False` fails 2.

**This is the one behaviour change in the PR**: column 8 stops being a constant. Column count and positions are untouched, and the analyzer already sums the column.

## The legacy path that could blacklist a live pano

`download_single_pano` read a `<pano_id>.xml` for dims and zoom. #39 removed the downloader that wrote those files (`cbk?output=xml` died in 2022), so every one still on the store is frozen 2022 metadata. The block sits *after* the "image already exists → skipped" return, so it can only run for a pano with an `.xml` and **no** `.jpg`. Measured on the makelab2 store across dc, columbus-oh, amsterdam and newberg-or: of **1,025** `.xml` files, exactly **one** had no `.jpg` beside it (seattle has none at all).

On that one pano it was not harmless. A declared `num_zoom_levels` was trusted over the probe and test-fetched, and a black tile at that zoom returned `DownloadResult.failure` — **permanent** under the #41 ledger, written `downloaded=0` and never re-attempted. So stale 2022 metadata could blacklist a pano Google serves fine today. A test asserts `success` and fails with `failure` against the old code.

Deleting it also takes item 3's `ET` import, item 4's `print(xml_metadata_path)`, and item 5's `except Exception: pass` (which made a malformed XML indistinguishable from no XML at all).

## The rest

- **`DownloadResult` is `enum.Enum`** (not `IntEnum`). `skipped` was index `0` and therefore falsy; a typo raised `ValueError` from `__getattr__` so `hasattr` raised instead of answering; members printed as bare ints. Nothing compares these to ints or does arithmetic on them, so there is no reason to keep them int-like.
- **`CropRunner`'s `-s` and `-o` are required.** `-o` defaulted to the filesystem root (needs sudo on Linux, lands on the system drive on Windows) and `-s` to the Docker container's scratch path — and the container runs `DownloadRunner`, not `CropRunner`. Forgetting one wrote an ML training corpus somewhere nobody would look for it. Every `main([...])` test already passed both, as does the README example.
- **`FDQN` → `FQDN`** in help text and `CropRunner`'s parameter names.
- **`flag_panos/json_to_csv.py`** gets `build_parser()` / `main(argv)` under a guard, a `--city` argument (it was a `CITY = 'amsterdam'` module constant), and an error naming the city, the directory and both filenames it looked for.

## On item 6's "print vs logging is mixed"

Not resolved by a sweep, and deliberately. stdout here is a documented ops channel — README leans on a `WARNING` reaching cron mail, and ~15 tests assert on `capsys`. Converting either direction breaks both. The rule is now written down in `CLAUDE.md` instead: **`print` is the operator-facing narrative cron mails, `logging` is the durable per-item record, and a warning that matters goes to both.** The one real violation, `filter_supported_sources` warning on stdout only, is fixed with `caplog` assertions beside its `capsys` ones so a revert fails.

Also deliberately unchanged: the three per-pano stdout lines in the image loop. #52 filed the *per-item* prints as debug leftovers, and the two it meant are both already gone; what remains is the run narrative.

## Verification

- Full suite **1493 passed, 24 skipped** (baseline 1471/24 — 22 new tests).
- End to end, not just the suite: a real `DownloadRunner` run writes an 18-field `log.csv`, exits 0, and the unsupported-source warning lands on stdout **and** in `scrape.log` on the store.
- `import DownloadRunner, CropRunner, downloaders, flag_panos.json_to_csv` produces no output and no files.
- `python3 CropRunner.py -d x.invalid` exits 2 naming `-s, -o`.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])
