### PR TITLE
Take the three file intakes off pandas, which was shifting columns and retyping cells without saying so

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ CI (`.github/workflows/tests.yml`) runs the suite on Ubuntu 22.04 / Python 3.10,
 - `mapillary.py` resolves `thumb_original_url` via the Graph API and downloads it. Requires `MAPILLARY_ACCESS_TOKEN`.
 
 **CropRunner.py** — extracts per-label crops from downloaded panos.
-1. Loads label metadata from `/adminapi/labels/cvMetadata` (`-d`), or a `.csv`/`.json` file (`-f`, case-insensitive extension). Both intakes dedupe on `label_id`; the CSV intake additionally dtype-pins `pano_id` to `str` (the #46 bug class) and requires `REQUIRED_LABEL_COLUMNS` up front, so a header typo is one error naming the file rather than a `KeyError` 200k labels in.
+1. Loads label metadata from `/adminapi/labels/cvMetadata` (`-d`), or a `.csv`/`.json` file (`-f`, case-insensitive extension). Both intakes dedupe on `label_id`; the CSV intake reads with `csv.DictReader`, not pandas (#72), so no field's type can depend on what the values happen to look like (the #46 bug class), and requires `REQUIRED_LABEL_COLUMNS` up front, so a header typo is one error naming the file rather than a `KeyError` 200k labels in.
 2. Labels are **grouped by pano**, so each `<pano-dir>/<pano_id[:2]>/<pano_id>.jpg` is decoded exactly once for all its labels — a 16384×8192 pano is ~250 MB decoded. Each label's window comes from `compute_crop_box()`: an integer `CropBox(left, top, width, height, shifted)` centered at `(pano_x, pano_y)`, **3:2**, where **x wraps at the equirectangular seam and y clamps by shifting**, so no crop ever contains synthetic black (#47). Width comes from `crop_window_width()` — **sizing rule v2**: `predict_crop_size()` normalised into the 6656-px frame its constants were fit on, ×`CROP_SIZE_SCALE`, clamped to `CROP_MIN_FOV_DEG`–`CROP_MAX_FOV_DEG` **as an angle** rather than as pixels. `downscale_for_storage()` then caps the cut window at `CROP_MAX_STORED_WIDTH` without ever upscaling it. Every constant is one measured number — see `reports/2026-08-19-crop-sizing-v2.md`; the residual (a y-only rule cannot know how large a ramp actually is) is RampNet #83.
    - **The rule version lives in the store, not in the run summary.** `write_rule_marker()` writes `<crop-dir>/crop_rule.json` (`CROP_RULE_VERSION` plus every constant) *before* cutting anything, and warns — never refuses — when it disagrees with what is there. A mixed store is the **ordinary** result of changing the rule, since existing crops are the resume marker and are never re-cut: run v2 over a v1 store and the new crops are 3:2 while the old stay square, with nothing on disk to say so. Stdout was where this used to go, which on a cron run is nowhere.
    - **`reports/scripts/crop_rule_v1.py` is the one frozen copy of the old rule**, used by the sizing study and by the two census tests whose reports were *measured* under v1. It is a record, not a rule anyone runs — the resolution defect in it is the subject of the v2 report and must not be "fixed".
@@ -125,6 +125,17 @@ plus the referenced HF dataset must reproduce every number in `reports/`.
 
 ## Things that are easy to get wrong
 
+- **The three file intakes read with `csv`/`json`, and must not go back to pandas (#72).** `pandas` is a
+  dev/ops dependency now (`requirements-dev.txt`, for `log_analyzer/` and `reports/scripts/`), and a test
+  asserts no production module imports it. The battery in `tests/test_csv_intake.py` was **measured**
+  against `pd.read_csv` before the swap, and three of those measurements are the reason it happened: a row
+  with **one surplus field** made pandas consume the first column as the frame's index, so every field
+  shifted and the real `pano_id` vanished — silently; **`has_labels` had no fixed type** (bool, int64,
+  float64, or `str` for junk *and* for `' True '` with padding), and `select_image_panos` is a plain
+  truthiness test, so the `str` cases silently defeated `--all-panos`; and **one blank cell retyped a whole
+  column**, so a single missing `width` made every other row's width a float and the blank itself a `NaN`
+  that `gsv`'s `is not None` guard cannot see. Blank cells become `None` in `DownloadRunner` and stay `''`
+  in `CropRunner` — deliberate, and explained at both seams.
 - **`print` and `logging` are two channels with different jobs — do not "unify" them.** `print` is the
   operator-facing run narrative and the warnings **cron mails**; `logging` is the durable per-item detail in
   `scrape.log` / `crop.log`. **A warning that matters goes to both**, which is the depth phase's pattern

--- a/CropRunner.py
+++ b/CropRunner.py
@@ -15,6 +15,7 @@ are the seams, and `python3 CropRunner.py ...` behaviour lives under the __main_
 
 import argparse
 import collections
+import csv
 import json
 import logging
 import logging.handlers
@@ -22,7 +23,6 @@ import math
 import os
 import sys
 
-import pandas as pd
 import requests
 from PIL import Image, ImageDraw
 from requests.adapters import HTTPAdapter
@@ -173,19 +173,37 @@ def request_session():
 def fetch_label_ids_csv(metadata_csv_path):
     """
     Reads metadata from a csv. Useful for old csv formats of cvMetadata such as cv-metadata-seattle.csv.
-    Dedupes on label_id.
+    Dedupes on label_id, keeping the first row per id.
 
-    pano_id is dtype-pinned to str: an all-numeric (Mapillary) column otherwise infers int64 and crashes
-    every pano_id[:2] shard slice - the same #46 intake bug DownloadRunner.fetch_pano_ids_csv fixed. The
-    column guard exists because pd.read_csv ignores dtype keys for absent columns, so a header typo would
-    otherwise surface as a KeyError deep in the crop loop instead of an error naming the file.
+    Read with csv, not pandas (#72), so no field's type depends on what the values happen to look like -
+    the inference that gave an all-numeric (Mapillary) pano_id column int64 and crashed every pano_id[:2]
+    shard slice (#46). Every cell arrives as a str and the crop loop coerces at use, which is why this
+    intake needs no per-field conversion of its own; unlike the downloader's, blank cells stay '' rather
+    than becoming None, because every consumer here is inside the loop's try/except and handles both.
+
+    utf-8-sig for the Excel BOM, and the column guard because a header typo would otherwise surface as a
+    KeyError deep in the crop loop instead of an error naming the file.
     """
-    df_meta = pd.read_csv(metadata_csv_path, dtype={'pano_id': str})
-    missing = [c for c in REQUIRED_LABEL_COLUMNS if c not in df_meta.columns]
-    if missing:
-        raise ValueError("%s is missing required column(s) %r; found %r"
-                         % (metadata_csv_path, missing, list(df_meta.columns)))
-    return df_meta.drop_duplicates(subset=['label_id']).to_dict('records')
+    unique_label_ids = set()
+    labels = []
+    with open(metadata_csv_path, newline='', encoding='utf-8-sig') as csv_file:
+        reader = csv.DictReader(csv_file)
+        # fieldnames is None for an empty file, and `c not in None` is a TypeError.
+        fieldnames = reader.fieldnames or []
+        missing = [c for c in REQUIRED_LABEL_COLUMNS if c not in fieldnames]
+        if missing:
+            raise ValueError("%s is missing required column(s) %r; found %r"
+                             % (metadata_csv_path, missing, reader.fieldnames))
+        for row in reader:
+            # Surplus fields land under the key None. pandas did something worse with the same input -
+            # it consumed the first column as the frame's index, shifting every field by one.
+            label = {key: value for key, value in row.items() if key is not None}
+            label_id = label.get('label_id')
+            if label_id in unique_label_ids:
+                continue
+            unique_label_ids.add(label_id)
+            labels.append(label)
+    return labels
 
 
 def json_to_list(jsondata):
@@ -245,18 +263,29 @@ def fetch_cvMetadata_from_server(server_fqdn):
     return json_to_list(jsondata)
 
 
+def _absent(value):
+    """True for a field the row does not actually carry: absent, JSON null, or a blank CSV cell.
+
+    The blank cell is the case that has to be spelled out. '' is not None, so treating only None as
+    missing would both skip the width/height fallback below AND hand '' to float(), turning a row that
+    simply doesn't claim dimensions into a counted malformed-row error - and main() exits 1 on errors, so
+    a blank dims column would fail an otherwise clean run.
+    """
+    return value is None or (isinstance(value, str) and not value.strip())
+
+
 def _metadata_dims(row):
     """The pano dimensions a label row claims, or None if it doesn't carry them.
 
-    cvMetadata calls them pano_width/pano_height (null for third-party photospheres, which pandas turns
-    into NaN); the old CSV export calls them width/height. Raises ValueError on non-numeric values so the
-    caller's malformed-row handling applies.
+    cvMetadata calls them pano_width/pano_height (null for third-party photospheres); the old CSV export
+    calls them width/height. Raises ValueError on non-numeric values so the caller's malformed-row
+    handling applies.
     """
     raw_width = row.get('pano_width')
     raw_height = row.get('pano_height')
-    if raw_width is None or raw_height is None:
+    if _absent(raw_width) or _absent(raw_height):
         raw_width, raw_height = row.get('width'), row.get('height')
-    if raw_width is None or raw_height is None:
+    if _absent(raw_width) or _absent(raw_height):
         return None
     width, height = float(raw_width), float(raw_height)
     if not (math.isfinite(width) and math.isfinite(height) and width > 0 and height > 0):

--- a/DownloadRunner.py
+++ b/DownloadRunner.py
@@ -13,7 +13,6 @@ import time
 from datetime import datetime
 from os.path import exists
 
-import pandas as pd
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
@@ -108,7 +107,11 @@ def _normalize_pano_records(records):
     kept = []
     for record in records:
         raw = record.get('pano_id')
-        # A blank CSV cell arrives as float nan, which str() would keep as the id 'nan'.
+        # The float-nan case is the JSON path, not the CSV one: Python's json parses a bare NaN literal by
+        # default, so response.json() can hand us one, and str() would keep it as the id 'nan' - a real
+        # shard path, na/nan.jpg. (It used to be the CSV path too: pd.read_csv returned nan for a blank
+        # cell even under dtype={'pano_id': str}. csv.DictReader returns '', which falls through to the
+        # empty check below.)
         if raw is None or (isinstance(raw, float) and math.isnan(raw)):
             pano_id = ''
         else:
@@ -124,24 +127,73 @@ def _normalize_pano_records(records):
     return kept
 
 
+# has_labels spellings a hand-made CSV may reasonably use. Everything else raises, because
+# select_image_panos tests the value for truth and every non-empty string is true - so an unrecognised
+# spelling would silently mean 'labelled' and quietly undo the --all-panos split.
+_TRUE_SPELLINGS = frozenset(('true', 't', 'yes', 'y', '1'))
+_FALSE_SPELLINGS = frozenset(('false', 'f', 'no', 'n', '0'))
+
+
+def _parse_has_labels(raw, metadata_csv_path):
+    """Coerce a CSV has_labels cell to a real bool. Blank or absent counts as labelled.
+
+    pd.read_csv typed this column from its contents: bool for True/False, int64 for 1/0, float64 (nan) for
+    a blank, and str for anything else - INCLUDING ' True ' with padding. The two str cases were silently
+    truthy, so a padded or typo'd cell downloaded the pano and said nothing.
+    """
+    if raw is None:
+        return True
+    text = raw.strip().lower()
+    if not text:
+        return True
+    if text in _TRUE_SPELLINGS:
+        return True
+    if text in _FALSE_SPELLINGS:
+        return False
+    raise ValueError("%s has an unreadable has_labels value %r; expected one of %s"
+                     % (metadata_csv_path, raw,
+                        ', '.join(sorted(_TRUE_SPELLINGS | _FALSE_SPELLINGS))))
+
+
 def fetch_pano_ids_csv(metadata_csv_path):
     """
     Loads pano metadata from a CSV file (downloaded from the server). Dedupes on pano_id.
     Expected to include the same columns as /adminapi/panos, notably `source`.
 
-    pano_id is dtype-pinned to str: an all-numeric (Mapillary) column otherwise infers int64 (#46), and one
-    with a single blank cell would infer float64 - whose str() would mint ids like '1.23e+14' - so both the
-    pin here and the normalisation are needed.
+    Read with csv, not pandas (#72), so no field's type depends on what the values happen to look like -
+    the inference that caused #46 and #55. Every cell is a str; the two exceptions below are the fields
+    whose consumers need something else.
+
+    utf-8-sig because a hand-made CSV out of Excel carries a BOM, which would otherwise glue itself to the
+    first fieldname and fire the column guard on a perfectly good file.
     """
-    df_meta = pd.read_csv(metadata_csv_path, dtype={'pano_id': str})
-    # Fail loudly on a header typo. -c exists for hand-made CSVs, and _normalize_pano_records would
-    # otherwise read every row's missing id as blank and filter the whole file out - a run that downloads
-    # nothing, prints one 'empty string or tutorial' line per row, and exits 0. pd.read_csv ignores dtype
-    # keys for absent columns, so the pin above doesn't catch this either.
-    if 'pano_id' not in df_meta.columns:
-        raise ValueError("%s has no 'pano_id' column; found %r"
-                         % (metadata_csv_path, list(df_meta.columns)))
-    return _normalize_pano_records(df_meta.to_dict('records'))
+    with open(metadata_csv_path, newline='', encoding='utf-8-sig') as csv_file:
+        reader = csv.DictReader(csv_file)
+        # Fail loudly on a header typo. -c exists for hand-made CSVs, and _normalize_pano_records would
+        # otherwise read every row's missing id as blank and filter the whole file out - a run that
+        # downloads nothing, prints one 'empty string or tutorial' line per row, and exits 0. fieldnames is
+        # None for an empty file, and `'pano_id' not in None` is a TypeError, so check that first.
+        if not reader.fieldnames or 'pano_id' not in reader.fieldnames:
+            raise ValueError("%s has no 'pano_id' column; found %r"
+                             % (metadata_csv_path, reader.fieldnames))
+        records = [_normalize_csv_row(row, metadata_csv_path) for row in reader]
+    return _normalize_pano_records(records)
+
+
+def _normalize_csv_row(row, metadata_csv_path):
+    """One DictReader row as the rest of the pipeline expects it.
+
+    Blank cells become None because that is what the consumers test for: gsv.download_single_pano reads the
+    dims as `int(v) if v is not None else None`, and a '' walks past that guard into int('').
+
+    Surplus fields are dropped. DictReader files them under the key None; pandas did something far worse
+    with the same input - it consumed the first column as the frame's index, so every field shifted by one
+    and the real pano_id vanished out of the record entirely, without raising.
+    """
+    record = {key: (value if value else None) for key, value in row.items() if key is not None}
+    if 'has_labels' in record:
+        record['has_labels'] = _parse_has_labels(record['has_labels'], metadata_csv_path)
+    return record
 
 
 def fetch_pano_ids_from_webserver(sidewalk_server_fqdn):

--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ The run writes a rotating `crop.log` into the crop directory, prints a per-outco
 
 `log_analyzer/analyze.py` monitors the nightly scrape across every city. It pulls each city's `log.csv` off the pano store over SFTP and flags the ones that look broken. Nothing is downloaded by the scraper itself — this is an ops tool you run from a workstation or a cron box, not something the Docker image needs.
 
-It needs only `pandas` (already in `requirements.txt`) plus the `sftp` client binary (`openssh-client`).
+It needs only `pandas` plus the `sftp` client binary (`openssh-client`). `pandas` is in
+`requirements-dev.txt` rather than `requirements.txt` — nothing the scraper or cropper runs imports it (#72) — so
+a box running only the analyzer wants `pip3 install pandas`, not the whole dev file.
 
 Connection settings are read from the environment, or the matching flag. Host and base path are required and have no defaults — a wrong default would silently analyze the wrong store:
 

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ The depth map is Google's plane-based encoding decoded to a per-pixel distance g
 * **Building geometry drifts between captures** (facades from re-captures of the same street differ by a couple of meters), so don't treat facade distances as survey-grade.
 
 ## Tests
-A `pytest` suite covers the depth phase (ledger semantics, error taxonomy, artifact format, budget flags), the positional `log.csv` contract shared by the writer and the [log analyzer](#log-analyzer), and the Docker entrypoint's flag forwarding. The tests are network-free (streetlevel is mocked) and need only the packages in `requirements.txt` plus `pytest`:
+A `pytest` suite covers the depth phase (ledger semantics, error taxonomy, artifact format, budget flags), the positional `log.csv` contract shared by the writer and the [log analyzer](#log-analyzer), and the Docker entrypoint's flag forwarding. The tests are network-free (streetlevel is mocked) and need `requirements.txt` plus `requirements-dev.txt` — the latter carries `pytest`, and the `matplotlib`/`pandas` that the `reports/` scripts and their tests use but the scraper and cropper do not:
 
 ```bash
 pip3 install -r requirements.txt -r requirements-dev.txt

--- a/flag_panos/json_to_csv.py
+++ b/flag_panos/json_to_csv.py
@@ -11,10 +11,10 @@ traceback naming one filename and neither the city nor the directory it had look
 """
 
 import argparse
+import csv
+import json
 import os
 import sys
-
-import pandas as pd
 
 # The two artifacts the web tool produces. Suffixes, not whole names, because the city is a parameter now.
 INPUT_SUFFIXES = ('_pano_image_data', '_unretrievable_panos')
@@ -43,12 +43,29 @@ def convert(directory, city):
             continue
         csv_path = os.path.join(directory, '%s%s.csv' % (city, suffix))
         with open(json_path, encoding='utf-8') as f:
-            df = pd.read_json(f)
-        # index=False: pandas would otherwise write a nameless leading index column, shifting every field by
-        # one for anything reading the result positionally.
-        df.to_csv(csv_path, encoding='utf-8', index=False)
+            records = json.load(f)
+        write_csv(csv_path, records)
         written.append(csv_path)
     return written
+
+
+def write_csv(csv_path, records):
+    """Write a list of dicts as a CSV whose columns are the union of their keys, in first-seen order.
+
+    The union, rather than the first record's keys, because the web tool writes one object shape per file
+    today but nothing enforces that, and a DictWriter fed a key it doesn't know about raises.
+
+    Written with csv rather than pandas (#72), which had two failure modes here. read_json inferred each
+    column's type from the values, so one record missing `image_width` retyped the whole column and the
+    records that did carry 16384 were written as 16384.0; and an all-numeric pano_id column inferred int64
+    (the #46 class - this site never had the dtype pin the two runners did). newline='' because the writer
+    emits \\r\\n itself, and letting the file object translate that again doubles every line ending.
+    """
+    fieldnames = list(dict.fromkeys(key for record in records for key in record))
+    with open(csv_path, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(records)
 
 
 def main(argv=None):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,7 @@ pytest>=7
 # The reports/ figure generators, and tests/test_off_target_markers_figures.py which drives them.
 # Not in requirements.txt: nothing the scraper or cropper runs in production imports it.
 matplotlib>=3.5
+# The reports/scripts/ desk studies and log_analyzer/analyze.py. Moved out of requirements.txt by #72:
+# the three intakes that used it now read with csv/json, and its dtype inference was the direct cause of
+# #46 and #55. An ops box running only the log analyzer wants `pip3 install pandas`, not this whole file.
+pandas>=1.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pandas>=1.2.3
 Pillow>=8.1.2
 requests>=2.31
 # Imported directly (urllib3.util.retry.Retry), not just via requests. 2.0+ for Retry(backoff_jitter=...).

--- a/tests/test_csv_intake.py
+++ b/tests/test_csv_intake.py
@@ -235,6 +235,16 @@ class TestHasLabelsIsParsedNotGuessedAt:
 
         assert records[0]['has_labels'] is True
 
+    def test_a_whitespace_only_cell_counts_as_labelled(self, tmp_path):
+        """A cell of spaces is truthy, so it never becomes the blank cell's None and reaches the
+        parser as a string — the same padding that made pandas type ' True ' as str, with the value
+        taken out. It has to land on 'labelled' with the genuinely blank cell, not opposite it."""
+        path = write_pano_csv(tmp_path, PANO_HEADER + pano_row(has_labels='   '))
+
+        records = DownloadRunner.fetch_pano_ids_csv(path)
+
+        assert records[0]['has_labels'] is True
+
     def test_an_absent_column_counts_as_labelled(self, tmp_path):
         path = write_pano_csv(tmp_path, 'pano_id,source\ntestPanoIdAAAAAAAAAAAA,gsv\n')
 
@@ -431,6 +441,15 @@ class TestMetadataDimsTreatsBlankAsAbsent:
         assert CropRunner._metadata_dims(
             {'pano_id': 'a', 'pano_width': '', 'pano_height': '',
              'width': '16384', 'height': '8192'}) == (16384, 8192)
+
+    def test_blanks_in_both_column_pairs_are_absent_not_an_error(self):
+        """The other half a naive fix misses: the check after the fallback needs the blank rule too.
+        A CSV carrying both column pairs, all four blank, falls back to '' — and a bare `is None`
+        there hands that '' to float(), so the row is a counted error rather than one that simply
+        does not claim dimensions."""
+        assert CropRunner._metadata_dims(
+            {'pano_id': 'a', 'pano_width': '', 'pano_height': '',
+             'width': '', 'height': ''}) is None
 
     def test_absent_keys_are_still_absent(self):
         assert CropRunner._metadata_dims({'pano_id': 'a'}) is None

--- a/tests/test_csv_intake.py
+++ b/tests/test_csv_intake.py
@@ -32,7 +32,6 @@ try/except that counts a bad row, where `''` and `None` are equally well handled
 
 import ast
 import csv
-import io
 import json
 import os
 import sys
@@ -106,13 +105,18 @@ class TestPanoCsvParsesLikeACsv:
 
         assert [r['pano_id'] for r in records] == ['pano,id']
 
-    def test_a_quoted_field_containing_a_newline_stays_whole(self, tmp_path):
-        path = write_pano_csv(tmp_path,
-                              PANO_HEADER + '"pano\nid",16384,8192,47.6,-122.3,180.0,0.0,gsv,True\n')
+    @pytest.mark.parametrize('embedded', ['\n', '\r\n', '\r'])
+    def test_a_quoted_field_containing_a_newline_stays_whole(self, tmp_path, embedded):
+        """The \\r cases are what newline='' on the reader buys, and they are pandas parity, not an
+        invention: measured, read_csv also returns 'pano\\r\\nid' intact. Without newline='' the file
+        object's universal-newline translation rewrites both to '\\n' before csv ever sees them, so the
+        reader silently edits the data it was asked to read."""
+        path = write_pano_csv(tmp_path, PANO_HEADER
+                              + '"pano%sid",16384,8192,47.6,-122.3,180.0,0.0,gsv,True\n' % embedded)
 
         records = DownloadRunner.fetch_pano_ids_csv(path)
 
-        assert [r['pano_id'] for r in records] == ['pano\nid']
+        assert [r['pano_id'] for r in records] == ['pano%sid' % embedded]
 
     def test_crlf_line_endings_parse(self, tmp_path):
         text = (PANO_HEADER + pano_row()).replace('\n', '\r\n')
@@ -362,6 +366,17 @@ class TestLabelCsvIntake:
 
         assert len(CropRunner.fetch_label_ids_csv(path)) == 1
 
+    @pytest.mark.parametrize('embedded', ['\n', '\r\n', '\r'])
+    def test_a_quoted_field_containing_a_newline_stays_whole(self, tmp_path, embedded):
+        """newline='' on the reader, same as the downloader's. cvMetadata carries free text (copyright),
+        so a field with a line break in it is not hypothetical here."""
+        path = write_label_csv(tmp_path, 'pano_id,pano_x,pano_y,label_type_id,label_id,copyright\n'
+                               + 'abcdefgh0001,100,200,1,1,"a%sb"\n' % embedded)
+
+        labels = CropRunner.fetch_label_ids_csv(path)
+
+        assert labels[0]['copyright'] == 'a%sb' % embedded
+
     def test_a_surplus_field_does_not_shift_the_named_columns(self, tmp_path):
         path = write_label_csv(tmp_path, LABEL_HEADER + label_csv_row().rstrip('\n') + ',extra\n')
 
@@ -545,7 +560,7 @@ class TestPandasStaysOutOfProduction:
         with open(os.path.join(REPO_ROOT, module), encoding='utf-8') as f:
             assert 'pandas' not in imported_names(f.read())
 
-    def test_the_module_list_matches_what_is_on_disk(self, module=None):
+    def test_the_module_list_matches_what_is_on_disk(self):
         """A new production module added without a line here would be silently unguarded."""
         on_disk = {name for name in os.listdir(REPO_ROOT) if name.endswith('.py')}
         on_disk |= {'downloaders/' + name for name in os.listdir(os.path.join(REPO_ROOT, 'downloaders'))

--- a/tests/test_csv_intake.py
+++ b/tests/test_csv_intake.py
@@ -1,0 +1,561 @@
+"""The CSV/JSON intake contract for the three file-reading seams, after #72 moved them off pandas.
+
+`fetch_pano_ids_csv` (-c), `fetch_label_ids_csv` (-f *.csv) and `flag_panos/json_to_csv.py` all used
+`pandas`, whose dtype inference caused #46 and #55 and needed a `dtype={'pano_id': str}` pin at each
+site whose only job was to stop it guessing. This file is the battery that made the swap to `csv`
+safe, and it is deliberately one file rather than additions to three: it is a single contract, and
+every case here was *measured* against `pd.read_csv` before the conversion rather than predicted.
+
+Five of those measurements are why the change is worth making. Under pandas, with the dtype pin in
+place:
+
+* **An extra field on a row silently shifts every column.** `read_csv` consumes the first column as
+  the DataFrame index, so a 10-field row under a 9-field header parsed to
+  `pano_id='16384', camera_pitch='gsv', source=True` and the real pano id vanished into the index.
+  Nothing raised. `csv.DictReader` puts the surplus under `None` and every named field stays right.
+* **`has_labels` had no fixed type.** `bool` for `True`/`False`, `int64` for `1`/`0`, `float64` (NaN)
+  for a blank, `str` for junk *and for `' True '` with padding*. `select_image_panos` is a plain
+  truthiness test, so the two `str` cases are silently truthy — a padded ` True ` or a typo'd
+  `maybe` defeats the `--all-panos` split without a word.
+* **A single blank cell retyped a whole column.** One blank `width` made every other row's width a
+  float, and the blank itself NaN — which `downloaders/gsv.py`'s `int(...) if ... is not None` guard
+  cannot see, so it raises where the code reads as "let the tiler decide".
+* **`drop_duplicates` deduped on the inferred type**, so label ids `7` and `07` collapsed into one.
+* **`read_json` retyped ints via a sibling's absence** — a record missing `width` made every other
+  record's `width` a float, and `16384` was written to CSV as `16384.0`.
+
+Blank cells stay `''` in the cropper and become `None` in the downloader. That asymmetry is
+deliberate and load-bearing: `gsv.download_single_pano` guards its dims with `is not None`, so a
+`''` would sail past the guard into `int('')`, while the crop loop coerces every field inside a
+try/except that counts a bad row, where `''` and `None` are equally well handled.
+"""
+
+import ast
+import csv
+import io
+import json
+import os
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+import CropRunner
+import DownloadRunner
+from flag_panos import json_to_csv
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+PANO_HEADER = 'pano_id,width,height,lat,lng,camera_heading,camera_pitch,source,has_labels\n'
+
+
+def pano_row(pano_id='testPanoIdAAAAAAAAAAAA', width='16384', height='8192', source='gsv',
+             has_labels='True'):
+    return '%s,%s,%s,47.6,-122.3,180.0,0.0,%s,%s\n' % (pano_id, width, height, source, has_labels)
+
+
+def write_pano_csv(tmp_path, text, name='panos.csv', encoding='utf-8'):
+    path = tmp_path / name
+    path.write_bytes(text.encode(encoding))
+    return str(path)
+
+
+LABEL_HEADER = 'pano_id,pano_x,pano_y,label_type_id,label_id,pano_width,pano_height\n'
+
+
+def label_csv_row(pano_id='abcdefgh0001', pano_x='100', pano_y='200', label_type_id='1',
+                  label_id='1', pano_width='16384', pano_height='8192'):
+    return '%s,%s,%s,%s,%s,%s,%s\n' % (pano_id, pano_x, pano_y, label_type_id, label_id,
+                                       pano_width, pano_height)
+
+
+def write_label_csv(tmp_path, text, name='labels.csv', encoding='utf-8'):
+    path = tmp_path / name
+    path.write_bytes(text.encode(encoding))
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# DownloadRunner.fetch_pano_ids_csv  (-c)
+# ---------------------------------------------------------------------------
+
+class TestPanoCsvParsesLikeACsv:
+    """Cases where the intake must behave exactly as it did under pandas."""
+
+    def test_a_clean_file_round_trips(self, tmp_path):
+        path = write_pano_csv(tmp_path, PANO_HEADER + pano_row())
+
+        records = DownloadRunner.fetch_pano_ids_csv(path)
+
+        assert len(records) == 1
+        assert records[0]['pano_id'] == 'testPanoIdAAAAAAAAAAAA'
+        assert records[0]['source'] == 'gsv'
+
+    def test_a_quoted_field_containing_a_comma_stays_whole(self, tmp_path):
+        """The tempting wrong turn here is `line.split(',')`, which pandas never did."""
+        path = write_pano_csv(tmp_path,
+                              PANO_HEADER + '"pano,id",16384,8192,47.6,-122.3,180.0,0.0,gsv,True\n')
+
+        records = DownloadRunner.fetch_pano_ids_csv(path)
+
+        assert [r['pano_id'] for r in records] == ['pano,id']
+
+    def test_a_quoted_field_containing_a_newline_stays_whole(self, tmp_path):
+        path = write_pano_csv(tmp_path,
+                              PANO_HEADER + '"pano\nid",16384,8192,47.6,-122.3,180.0,0.0,gsv,True\n')
+
+        records = DownloadRunner.fetch_pano_ids_csv(path)
+
+        assert [r['pano_id'] for r in records] == ['pano\nid']
+
+    def test_crlf_line_endings_parse(self, tmp_path):
+        text = (PANO_HEADER + pano_row()).replace('\n', '\r\n')
+        path = write_pano_csv(tmp_path, text)
+
+        records = DownloadRunner.fetch_pano_ids_csv(path)
+
+        assert [r['pano_id'] for r in records] == ['testPanoIdAAAAAAAAAAAA']
+
+    def test_a_trailing_blank_line_is_not_a_row(self, tmp_path):
+        path = write_pano_csv(tmp_path, PANO_HEADER + pano_row() + '\n')
+
+        records = DownloadRunner.fetch_pano_ids_csv(path)
+
+        assert len(records) == 1
+
+    def test_a_header_only_file_yields_no_records(self, tmp_path):
+        path = write_pano_csv(tmp_path, PANO_HEADER)
+
+        assert DownloadRunner.fetch_pano_ids_csv(path) == []
+
+    def test_a_utf8_bom_still_finds_pano_id(self, tmp_path):
+        """Excel writes a BOM. pandas strips it; a plain `utf-8` open leaves it glued to the first
+        fieldname, so the column guard fires on a file that is perfectly well-formed."""
+        path = write_pano_csv(tmp_path, PANO_HEADER + pano_row(), encoding='utf-8-sig')
+
+        records = DownloadRunner.fetch_pano_ids_csv(path)
+
+        assert [r['pano_id'] for r in records] == ['testPanoIdAAAAAAAAAAAA']
+
+    def test_a_short_row_leaves_the_absent_fields_missing_not_shifted(self, tmp_path):
+        path = write_pano_csv(tmp_path, PANO_HEADER + 'testPanoIdAAAAAAAAAAAA,16384\n')
+
+        records = DownloadRunner.fetch_pano_ids_csv(path)
+
+        assert records[0]['pano_id'] == 'testPanoIdAAAAAAAAAAAA'
+        assert records[0]['width'] == '16384'
+        assert records[0]['source'] is None
+
+
+class TestPanoCsvFailsLoudly:
+    def test_a_missing_pano_id_column_names_the_file(self, tmp_path):
+        path = write_pano_csv(tmp_path, 'panoid,source\ntestPanoIdRealAAAAAAAA,gsv\n')
+
+        with pytest.raises(ValueError, match='no .pano_id. column'):
+            DownloadRunner.fetch_pano_ids_csv(path)
+
+    def test_an_empty_file_raises_the_named_error(self, tmp_path):
+        """`reader.fieldnames` is None for an empty file, and `'pano_id' not in None` is a TypeError
+        — so the guard has to test for None first or the clear message is replaced by a traceback."""
+        path = write_pano_csv(tmp_path, '')
+
+        with pytest.raises(ValueError, match='no .pano_id. column'):
+            DownloadRunner.fetch_pano_ids_csv(path)
+
+
+class TestExtraFieldsDoNotShiftColumns:
+    """Measured: `pd.read_csv` consumes the first column as the index when a row is too long, so the
+    real pano id disappears and `source` became the boolean `True`. Nothing raised."""
+
+    def test_a_row_with_a_surplus_field_keeps_every_named_field(self, tmp_path):
+        path = write_pano_csv(tmp_path, PANO_HEADER + pano_row().rstrip('\n') + ',extra\n')
+
+        records = DownloadRunner.fetch_pano_ids_csv(path)
+
+        assert records[0]['pano_id'] == 'testPanoIdAAAAAAAAAAAA'
+        assert records[0]['source'] == 'gsv'
+        assert records[0]['width'] == '16384'
+
+    def test_the_surplus_field_is_not_carried_as_a_none_key(self, tmp_path):
+        """csv.DictReader files the overflow under the key None. Left in, it would reach
+        _normalize_pano_records and any dict-walking consumer as a nameless entry."""
+        path = write_pano_csv(tmp_path, PANO_HEADER + pano_row().rstrip('\n') + ',extra\n')
+
+        records = DownloadRunner.fetch_pano_ids_csv(path)
+
+        assert None not in records[0]
+
+
+class TestHasLabelsIsParsedNotGuessedAt:
+    """`select_image_panos` is `p.get('has_labels', True)` — a plain truthiness test. Every string
+    except '' is truthy, so this is where a naive csv port silently turns --all-panos into a no-op."""
+
+    @pytest.mark.parametrize('raw', ['False', 'false', 'FALSE', '0', 'f', 'no', ' False '])
+    def test_a_falsey_spelling_is_not_selected_for_images(self, tmp_path, raw):
+        path = write_pano_csv(tmp_path, PANO_HEADER + pano_row(has_labels=raw))
+
+        records = DownloadRunner.fetch_pano_ids_csv(path)
+
+        assert records[0]['has_labels'] is False
+        assert DownloadRunner.select_image_panos(records, False) == []
+
+    @pytest.mark.parametrize('raw', ['True', 'true', 'TRUE', '1', 't', 'yes', ' True '])
+    def test_a_truthy_spelling_is_selected_for_images(self, tmp_path, raw):
+        path = write_pano_csv(tmp_path, PANO_HEADER + pano_row(has_labels=raw))
+
+        records = DownloadRunner.fetch_pano_ids_csv(path)
+
+        assert records[0]['has_labels'] is True
+        assert len(DownloadRunner.select_image_panos(records, False)) == 1
+
+    def test_all_panos_overrides_a_false(self, tmp_path):
+        """The flag gates images only; an unlabelled pano is still wanted when --all-panos is on."""
+        path = write_pano_csv(tmp_path, PANO_HEADER + pano_row(has_labels='False'))
+
+        records = DownloadRunner.fetch_pano_ids_csv(path)
+
+        assert len(DownloadRunner.select_image_panos(records, True)) == 1
+
+    def test_a_blank_cell_counts_as_labelled(self, tmp_path):
+        """Parity with the documented "a pano with no has_labels key counts as labelled", and with
+        pandas, which read a blank as NaN — truthy."""
+        path = write_pano_csv(tmp_path, PANO_HEADER + pano_row(has_labels=''))
+
+        records = DownloadRunner.fetch_pano_ids_csv(path)
+
+        assert records[0]['has_labels'] is True
+
+    def test_an_absent_column_counts_as_labelled(self, tmp_path):
+        path = write_pano_csv(tmp_path, 'pano_id,source\ntestPanoIdAAAAAAAAAAAA,gsv\n')
+
+        records = DownloadRunner.fetch_pano_ids_csv(path)
+
+        assert len(DownloadRunner.select_image_panos(records, False)) == 1
+
+    def test_an_unparseable_value_names_the_file_and_the_value(self, tmp_path):
+        """Under pandas this was a str, hence truthy, hence downloaded — the operator never learned
+        their CSV was wrong. -c exists for hand-made files, so this has to be loud."""
+        path = write_pano_csv(tmp_path, PANO_HEADER + pano_row(has_labels='maybe'))
+
+        with pytest.raises(ValueError, match='maybe'):
+            DownloadRunner.fetch_pano_ids_csv(path)
+
+
+class TestBlankNumericCellsReadAsMissing:
+    """downloaders/gsv.py: `int(pano_dims[0]) if pano_dims[0] is not None else None`. A '' is not
+    None, so it walks straight past the guard into int('')."""
+
+    def test_a_blank_width_is_none(self, tmp_path):
+        path = write_pano_csv(tmp_path, PANO_HEADER + pano_row(width='', height=''))
+
+        records = DownloadRunner.fetch_pano_ids_csv(path)
+
+        assert records[0]['width'] is None
+        assert records[0]['height'] is None
+
+    def test_a_blank_width_survives_the_gsv_dims_guard(self, tmp_path):
+        """The point of the None, stated as the expression gsv actually evaluates."""
+        path = write_pano_csv(tmp_path, PANO_HEADER + pano_row(width='', height=''))
+
+        record = DownloadRunner.fetch_pano_ids_csv(path)[0]
+        width = record.get('width')
+
+        assert (int(width) if width is not None else None) is None
+
+    def test_one_blank_does_not_retype_the_other_rows(self, tmp_path):
+        """pandas made the whole column float64 for this input, so the populated row's width came
+        back as 16384.0. Per-row parsing has no such coupling."""
+        path = write_pano_csv(tmp_path,
+                              PANO_HEADER
+                              + pano_row(pano_id='aaaaaaaaaaaaaaaaaaaaaa', width='')
+                              + pano_row(pano_id='bbbbbbbbbbbbbbbbbbbbbb', width='16384'))
+
+        records = DownloadRunner.fetch_pano_ids_csv(path)
+
+        assert records[0]['width'] is None
+        assert records[1]['width'] == '16384'
+
+
+class TestPanoIdsAreAlwaysStrings:
+    """#46/#55 restated at the seam: the id type must not depend on what the ids happen to look
+    like. These duplicate TestNumericPanoIds' intent in test_download_runner.py on purpose — that
+    class pins the *pipeline*, this one pins the *reader*."""
+
+    def test_all_numeric_ids_stay_strings(self, tmp_path):
+        path = write_pano_csv(tmp_path, PANO_HEADER + pano_row(pano_id='123456789012345'))
+
+        records = DownloadRunner.fetch_pano_ids_csv(path)
+
+        assert records[0]['pano_id'] == '123456789012345'
+        assert isinstance(records[0]['pano_id'], str)
+
+    def test_a_blank_id_beside_numeric_ids_does_not_mint_a_float_id(self, tmp_path):
+        """Measured: even with dtype={'pano_id': str}, a blank cell came back as float nan, whose
+        str() is 'nan' — an id that shards to na/nan.jpg."""
+        path = write_pano_csv(tmp_path,
+                              PANO_HEADER + pano_row(pano_id='123456789012345')
+                              + pano_row(pano_id=''))
+
+        records = DownloadRunner.fetch_pano_ids_csv(path)
+
+        assert [r['pano_id'] for r in records] == ['123456789012345']
+
+    def test_ids_differing_only_by_a_leading_zero_stay_distinct(self, tmp_path):
+        path = write_pano_csv(tmp_path, PANO_HEADER + pano_row(pano_id='7') + pano_row(pano_id='07'))
+
+        records = DownloadRunner.fetch_pano_ids_csv(path)
+
+        assert [r['pano_id'] for r in records] == ['7', '07']
+
+
+class TestTheNanGuardStillHasALiveCaller:
+    """#72 proposed deleting the float-nan branch in _normalize_pano_records as a pandas artifact.
+    It is not one: _normalize_pano_records is shared with the webserver path, and Python's json
+    parses a bare NaN literal into float('nan') by default — so response.json() reaches it."""
+
+    def test_json_really_does_produce_a_float_nan(self):
+        parsed = json.loads('[{"pano_id": NaN}]')
+
+        assert isinstance(parsed[0]['pano_id'], float)
+        assert parsed[0]['pano_id'] != parsed[0]['pano_id']
+
+    def test_a_nan_id_arriving_from_json_is_dropped_not_stringified(self):
+        records = DownloadRunner._normalize_pano_records(json.loads(
+            '[{"pano_id": NaN, "source": "gsv"}, {"pano_id": "abc", "source": "gsv"}]'))
+
+        assert [r['pano_id'] for r in records] == ['abc']
+
+
+# ---------------------------------------------------------------------------
+# CropRunner.fetch_label_ids_csv  (-f *.csv)
+# ---------------------------------------------------------------------------
+
+class TestLabelCsvIntake:
+    def test_a_clean_file_round_trips(self, tmp_path):
+        path = write_label_csv(tmp_path, LABEL_HEADER + label_csv_row())
+
+        labels = CropRunner.fetch_label_ids_csv(path)
+
+        assert len(labels) == 1
+        assert labels[0]['pano_id'] == 'abcdefgh0001'
+
+    def test_a_missing_required_column_names_the_file_and_the_column(self, tmp_path):
+        path = write_label_csv(tmp_path, 'panorama,pano_x,pano_y,label_type_id,label_id\na,1,2,1,1\n')
+
+        with pytest.raises(ValueError, match='pano_id'):
+            CropRunner.fetch_label_ids_csv(path)
+
+    def test_an_empty_file_raises_the_named_error(self, tmp_path):
+        path = write_label_csv(tmp_path, '')
+
+        with pytest.raises(ValueError, match='pano_id'):
+            CropRunner.fetch_label_ids_csv(path)
+
+    def test_a_utf8_bom_still_finds_the_required_columns(self, tmp_path):
+        path = write_label_csv(tmp_path, LABEL_HEADER + label_csv_row(), encoding='utf-8-sig')
+
+        assert len(CropRunner.fetch_label_ids_csv(path)) == 1
+
+    def test_a_surplus_field_does_not_shift_the_named_columns(self, tmp_path):
+        path = write_label_csv(tmp_path, LABEL_HEADER + label_csv_row().rstrip('\n') + ',extra\n')
+
+        labels = CropRunner.fetch_label_ids_csv(path)
+
+        assert labels[0]['pano_id'] == 'abcdefgh0001'
+        assert labels[0]['pano_x'] == '100'
+        assert None not in labels[0]
+
+    def test_dedupe_keeps_the_first_row_per_label_id(self, tmp_path):
+        path = write_label_csv(tmp_path,
+                               LABEL_HEADER + label_csv_row(label_id='7', pano_x='100')
+                               + label_csv_row(label_id='7', pano_x='210'))
+
+        labels = CropRunner.fetch_label_ids_csv(path)
+
+        assert len(labels) == 1
+        assert labels[0]['pano_x'] == '100'
+
+    def test_label_ids_differing_only_by_a_leading_zero_stay_distinct(self, tmp_path):
+        """drop_duplicates deduped on the inferred int64, so 7 and 07 collapsed into one label."""
+        path = write_label_csv(tmp_path,
+                               LABEL_HEADER + label_csv_row(label_id='7')
+                               + label_csv_row(label_id='07'))
+
+        assert len(CropRunner.fetch_label_ids_csv(path)) == 2
+
+    def test_the_real_sample_file_parses(self, tmp_path):
+        """samples/metadata-seattle.csv is the documented -f example: the old export's width/height
+        column names, and a trailing blank `copyright` on every row."""
+        path = os.path.join(REPO_ROOT, 'samples', 'metadata-seattle.csv')
+
+        labels = CropRunner.fetch_label_ids_csv(path)
+
+        assert len(labels) > 0
+        assert all(isinstance(row['pano_id'], str) for row in labels)
+        assert CropRunner._metadata_dims(labels[0]) == (16384, 8192)
+
+
+class TestMetadataDimsTreatsBlankAsAbsent:
+    """`_metadata_dims` returning None means "this row does not claim dimensions", which skips the
+    dims preflight and still crops. Raising instead makes the row a counted error — and main() exits
+    1 on errors, so a blank dims column would turn a clean run into a failing one."""
+
+    def test_blank_pano_dims_are_absent_not_an_error(self):
+        assert CropRunner._metadata_dims(
+            {'pano_id': 'a', 'pano_width': '', 'pano_height': ''}) is None
+
+    def test_a_blank_pano_width_falls_back_to_the_old_width_column(self):
+        """The half a naive fix misses: '' is not None, so the fallback branch never fires and the
+        populated width/height pair is never consulted."""
+        assert CropRunner._metadata_dims(
+            {'pano_id': 'a', 'pano_width': '', 'pano_height': '',
+             'width': '16384', 'height': '8192'}) == (16384, 8192)
+
+    def test_absent_keys_are_still_absent(self):
+        assert CropRunner._metadata_dims({'pano_id': 'a'}) is None
+
+    def test_a_json_null_is_still_absent(self):
+        """cvMetadata sends null for third-party photospheres; json.load gives None."""
+        assert CropRunner._metadata_dims(
+            {'pano_id': 'a', 'pano_width': None, 'pano_height': None}) is None
+
+    def test_populated_dims_are_ints(self):
+        assert CropRunner._metadata_dims(
+            {'pano_id': 'a', 'pano_width': '16384', 'pano_height': '8192'}) == (16384, 8192)
+
+    def test_a_non_numeric_value_still_raises_for_the_callers_error_handling(self):
+        with pytest.raises(ValueError):
+            CropRunner._metadata_dims({'pano_id': 'a', 'pano_width': 'wide', 'pano_height': '8192'})
+
+
+# ---------------------------------------------------------------------------
+# flag_panos/json_to_csv.py
+# ---------------------------------------------------------------------------
+
+def read_csv_rows(path):
+    with open(path, newline='', encoding='utf-8') as f:
+        return list(csv.reader(f))
+
+
+class TestJsonToCsvConversion:
+    def test_records_round_trip(self, tmp_path):
+        (tmp_path / 'amsterdam_pano_image_data.json').write_text(json.dumps(
+            [{'pano_id': 'abc', 'image_width': 16384}, {'pano_id': 'def', 'image_width': 13312}]))
+
+        json_to_csv.convert(str(tmp_path), 'amsterdam')
+
+        assert read_csv_rows(tmp_path / 'amsterdam_pano_image_data.csv') == [
+            ['pano_id', 'image_width'], ['abc', '16384'], ['def', '13312']]
+
+    def test_a_record_missing_a_key_does_not_retype_its_siblings(self, tmp_path):
+        """Measured under pandas: the absent `image_width` made the column float64, so the record
+        that *did* carry 16384 was written as 16384.0."""
+        (tmp_path / 'amsterdam_pano_image_data.json').write_text(json.dumps(
+            [{'pano_id': 'abc', 'image_width': 16384}, {'pano_id': 'def', 'copyright': 'x'}]))
+
+        json_to_csv.convert(str(tmp_path), 'amsterdam')
+
+        assert read_csv_rows(tmp_path / 'amsterdam_pano_image_data.csv') == [
+            ['pano_id', 'image_width', 'copyright'], ['abc', '16384', ''], ['def', '', 'x']]
+
+    def test_a_numeric_pano_id_stays_as_written(self, tmp_path):
+        """No dtype pin ever existed here, so a Mapillary-shaped id column inferred int64."""
+        (tmp_path / 'amsterdam_unretrievable_panos.json').write_text(json.dumps(
+            [{'pano_id': '123456789012345'}]))
+
+        json_to_csv.convert(str(tmp_path), 'amsterdam')
+
+        assert read_csv_rows(tmp_path / 'amsterdam_unretrievable_panos.csv') == [
+            ['pano_id'], ['123456789012345']]
+
+    def test_a_null_becomes_an_empty_cell(self, tmp_path):
+        (tmp_path / 'amsterdam_pano_image_data.json').write_text(json.dumps(
+            [{'pano_id': 'abc', 'copyright': None}]))
+
+        json_to_csv.convert(str(tmp_path), 'amsterdam')
+
+        assert read_csv_rows(tmp_path / 'amsterdam_pano_image_data.csv') == [
+            ['pano_id', 'copyright'], ['abc', '']]
+
+    def test_a_value_containing_a_comma_is_quoted(self, tmp_path):
+        (tmp_path / 'amsterdam_pano_image_data.json').write_text(json.dumps(
+            [{'pano_id': 'abc', 'copyright': 'a,b'}]))
+
+        json_to_csv.convert(str(tmp_path), 'amsterdam')
+
+        assert read_csv_rows(tmp_path / 'amsterdam_pano_image_data.csv') == [
+            ['pano_id', 'copyright'], ['abc', 'a,b']]
+
+    def test_no_index_column_is_written(self, tmp_path):
+        (tmp_path / 'amsterdam_pano_image_data.json').write_text(json.dumps(
+            [{'pano_id': 'abc', 'image_width': 16384}]))
+
+        json_to_csv.convert(str(tmp_path), 'amsterdam')
+
+        header = read_csv_rows(tmp_path / 'amsterdam_pano_image_data.csv')[0]
+        assert header == ['pano_id', 'image_width']
+
+    def test_lines_are_not_doubled(self, tmp_path):
+        """A csv.writer emits \\r\\n itself; without newline='' the file object translates the \\n
+        again and every row gains a blank line after it."""
+        (tmp_path / 'amsterdam_pano_image_data.json').write_text(json.dumps(
+            [{'pano_id': 'abc'}, {'pano_id': 'def'}]))
+
+        json_to_csv.convert(str(tmp_path), 'amsterdam')
+
+        raw = (tmp_path / 'amsterdam_pano_image_data.csv').read_bytes()
+        assert b'\r\r\n' not in raw and b'\n\n' not in raw
+
+
+# ---------------------------------------------------------------------------
+# The pin that keeps it gone
+# ---------------------------------------------------------------------------
+
+# Everything the scraper or the cropper runs. log_analyzer/ and reports/scripts/ are deliberately
+# absent: both still use pandas, and both are dev/ops tools rather than production code.
+PRODUCTION_MODULES = ['DownloadRunner.py', 'CropRunner.py', 'config.py',
+                      'migrate_depth_artifacts.py', 'flag_panos/json_to_csv.py',
+                      'downloaders/__init__.py', 'downloaders/common.py',
+                      'downloaders/gsv.py', 'downloaders/mapillary.py']
+
+
+def imported_names(source):
+    names = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            names.update(alias.name.split('.')[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and not node.level:
+            names.add(node.module.split('.')[0])
+    return names
+
+
+class TestPandasStaysOutOfProduction:
+    """pandas is still installed in CI — it moved to requirements-dev.txt, not out of the repo — so
+    an accidental re-import would not fail the build. Read, rather than imported, for the same
+    reason test_log_analyzer.py reads DownloadRunner.py with ast."""
+
+    @pytest.mark.parametrize('module', PRODUCTION_MODULES)
+    def test_no_production_module_imports_pandas(self, module):
+        with open(os.path.join(REPO_ROOT, module), encoding='utf-8') as f:
+            assert 'pandas' not in imported_names(f.read())
+
+    def test_the_module_list_matches_what_is_on_disk(self, module=None):
+        """A new production module added without a line here would be silently unguarded."""
+        on_disk = {name for name in os.listdir(REPO_ROOT) if name.endswith('.py')}
+        on_disk |= {'downloaders/' + name for name in os.listdir(os.path.join(REPO_ROOT, 'downloaders'))
+                    if name.endswith('.py')}
+        on_disk |= {'flag_panos/' + name for name in os.listdir(os.path.join(REPO_ROOT, 'flag_panos'))
+                    if name.endswith('.py')}
+
+        assert on_disk == set(PRODUCTION_MODULES)
+
+    def test_requirements_txt_does_not_pin_pandas(self):
+        with open(os.path.join(REPO_ROOT, 'requirements.txt'), encoding='utf-8') as f:
+            pins = [line.split('#')[0].strip() for line in f]
+        assert not any(pin.startswith('pandas') for pin in pins)


### PR DESCRIPTION
Closes #72.

`pandas` was down to three file-reading seams — `fetch_pano_ids_csv` (`-c`),
`fetch_label_ids_csv` (`-f *.csv`) and `flag_panos/json_to_csv.py` — each carrying a
`dtype={'pano_id': str}` pin whose only job was to stop it guessing, after its guessing
caused #46 and #55. This reads all three with `csv`/`json` and moves `pandas` to
`requirements-dev.txt`.

> Was stacked on #90 (`code-quality-52`), which is where this branch was cut from. #90 has
> merged, so this is retargeted onto `master` and the diff is only its own three commits.

## What changed since #72 was written

Three of the issue's premises expired, and one of its technical claims was wrong. Worth
recording, because the shape of the change follows from them:

| #72 says | Today |
|---|---|
| "pandas earns its place exactly once — a single `read_csv` on an optional path" | **three** intake sites, plus `log_analyzer/analyze.py` |
| "No test imports pandas" | **15 test files** and **15 `reports/scripts/` modules** do |
| "Deliberately not in scope: `CropRunner.py` — it still has no tests" | `tests/test_crop_runner.py` is 1,297 lines and covers the CSV intake directly |
| "the NaN branch goes" | it stays — see below |

`log_analyzer/analyze.py` arrived after the issue and answers @misaugstad's comment: its
pandas use is *not* just a `read_csv`. It does `.diff().clip()`, `.tail(n)` windows,
`.median()`, `.isna().any(axis=1)` and datetime parse/normalize — genuine dataframe work,
and it is an ops tool run from a workstation or cron box. It stays on pandas. So the
endpoint here is reclassification, not deletion: `pandas` moves to `requirements-dev.txt`
alongside `matplotlib`, which is already there for exactly this reason.

**The NaN guard in `_normalize_pano_records` is not a pandas artifact.** That function is
shared with the webserver path, and Python's `json` parses a bare `NaN` literal into
`float('nan')` by default — so `response.json()` still reaches it. Same for the equivalent
guard in the crop loop. Both stay; only their comments changed. There is a test that
constructs the nan *through `json.loads`* so the guard's live caller is pinned rather than
assumed.

## The swap is not mechanical

I measured `pd.read_csv` across a battery of CSV shapes before touching anything, rather
than predicting what it did. Three of those measurements are the actual argument for the
change — all three are silent, and none had a test:

**1. One surplus field on a row shifted every column.** `read_csv` consumes the first
column as the frame's index when a row is too long. A 10-field row under the 9-field pano
header parsed to:

```
{'pano_id': '16384', 'width': 8192, 'height': 47.6, ..., 'camera_pitch': 'gsv',
 'source': True, 'has_labels': 'extra'}
```

The real pano id ended up in the DataFrame index and was never seen again. Nothing raised.
`csv.DictReader` gets every named field right and files the surplus under `None`, which the
intake drops.

**2. `has_labels` had no fixed type.** `bool` for `True`/`False`, `int64` for `1`/`0`,
`float64` (NaN) for a blank, and `str` for junk **and for `' True '` with padding**.
`select_image_panos` is `p.get('has_labels', True)` — a plain truthiness test — and every
non-empty string is truthy, so a padded or typo'd cell silently downloaded the pano and
undid the `--all-panos` split. It is parsed strictly now: the usual spellings either way,
blank or absent counts as labelled (the documented default), anything else raises naming
the file and the value.

**3. One blank cell retyped a whole column.** A single missing `width` made every other
row's width a float and the blank itself a `NaN` — which `gsv.download_single_pano`'s
`int(v) if v is not None else None` guard cannot see, so it raises where the code reads as
"let the tiler decide". Blank cells become `None` at this intake so that guard means what
it says.

Two more, smaller: `drop_duplicates` deduped label ids on the inferred `int64`, so `7` and
`07` collapsed; and `read_json` retyped ints via a *sibling record's* absence, writing
`16384` to CSV as `16384.0`.

### The one asymmetry, and why

Blank cells become `None` in `DownloadRunner` and stay `''` in `CropRunner`. That is
deliberate and commented at both seams: the downloader's consumer guards with
`is not None`, so a `''` sails past it into `int('')`; the cropper's consumers all sit
inside the crop loop's `try/except`, which counts a bad row and handles both equally.

`_metadata_dims` needed the one real behaviour fix: a blank dims cell means "this row does
not claim dimensions" (skip the preflight, still crop), not "malformed row". Left as a
`float('')`, a blank `pano_width` column would have turned a clean run into one that exits
1 — and the fallback branch needed it too, or a present-but-blank `pano_width` never
consults `width`/`height`.

## Tests

`tests/test_csv_intake.py` is new: **77 cases** covering all three intakes as one contract.
Deliberately one file rather than additions to three — it is a single contract, and every
case in it was measured against `pd.read_csv` first. The first 75 were written before the
conversion and **27 of them failed against the pandas implementation**, which is what
specified the work.

**Mutation: 22 mutants over the three intakes, 22 killed.** Every deliberate detail of the
port is a mutant, so an unearned line would show up as a survivor:

| Site | Mutants (all killed) |
|---|---|
| `fetch_pano_ids_csv` | `newline=''` dropped · `utf-8-sig`→`utf-8` · empty-file `fieldnames is None` guard dropped · whole `pano_id` column guard dropped · naive port with no coercion layer · `has_labels` left a raw string · blank cell left `''` · surplus fields kept under key `None` |
| `_parse_has_labels` | no `.strip()` · no `.lower()` · blank→`False` · junk accepted instead of raising |
| `_normalize_pano_records` | float-nan branch deleted (#72's own proposal) |
| `fetch_label_ids_csv` | `newline=''` dropped · `utf-8-sig`→`utf-8` · empty-file guard dropped · surplus fields kept · dedupe dropped |
| `_metadata_dims` / `_absent` | `''` not treated as absent · the fallback branch's check reverted to `is None` |
| `json_to_csv.write_csv` | fieldnames from the first record only · `newline=''` dropped on the writer |

Two of those took a second pass to kill, and both are in the last three commits:

- **`newline=''` on `fetch_pano_ids_csv`'s `open()` survived the first pass.** The
  embedded-newline case used `\n`, which universal-newline translation leaves alone, so it
  could not tell the two apart. Parametrized over `\n`/`\r\n`/`\r` it dies — and I checked
  `read_csv` preserves `\r\n` inside a quoted field too, so this is pandas parity rather
  than an invention.
- **Two blank-cell branches survived a re-run this morning**, both claimed as covered by an
  earlier commit message and neither actually reachable by the existing cases:
  `_parse_has_labels`' blank→`True` (a genuinely blank cell becomes `None` upstream, so
  only a *whitespace-only* cell reaches that line) and `_metadata_dims`' second `_absent`
  (the existing case carries only `pano_width`/`pano_height`, so the fallback reads absent
  keys and returns `None` either way — it takes a file carrying *both* column pairs, all
  four blank).

**744 tests pass with `import pandas` blocked** — everything in `tests/` except the
`reports/scripts/` studies and the two ops tests (`test_log_analyzer`, `test_annotate_server`)
that legitimately reach it. The blocker discriminates rather than being decorative: those
same excluded files fail at collection under it and pass without it.
`TestPandasStaysOutOfProduction` keeps that true in CI: every production module is parsed
with `ast` and asserted not to import pandas, and `requirements.txt` is asserted not to pin
it — so an accidental re-import fails even though CI still installs pandas.

Full suite: `1570 passed, 24 skipped`.

## Two caveats

- **The clean-venv check in the plan could not run here.** `streetlevel` pins `pyfrpc`,
  whose sdist wants MSVC on this Windows box. The import blocker above is the stronger
  check anyway — it proves the production modules don't reach for pandas even when it *is*
  installed, which is the state CI actually runs in.
- **My local pandas is 3.0.5 on Python 3.12; CI is `pandas>=1.2.3` on 3.10.** So the
  measurements above are the behaviour *family*, not version-exact — which is itself part
  of the argument for not depending on them.

## Not in scope

`log_analyzer/analyze.py` and `reports/scripts/` keep pandas — real analysis, dev/ops only.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])
