### PR TITLE
Measure coverage honestly, then close the gaps it found (#57)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,66 @@
+# Coverage settings for `pytest --cov` (#57). See .github/workflows/tests.yml and the README's "Tests".
+#
+# Not pyproject.toml: adding one changes pytest's rootdir anchoring for nothing, and coverage reads a
+# pyproject only when a TOML parser is importable - which on the CI Python (3.10) arrives as a transitive
+# dependency rather than a guarantee, so a bare `coverage report` could ignore the config with no error.
+# Not setup.cfg either: conftest.py opens by saying the repo is not an installed package, and a setup.cfg
+# invites `pip install -e .`, which would break the sys.path-insert import model every test file relies on.
+
+[run]
+# The whole tree minus the omissions below, NOT a hand-listed set of files: a new production module has to
+# show up at 0%, not be invisible. That invisibility is the defect #57 was filed about.
+#
+# Written as an env substitution with `.` as the default because coverage resolves a relative source against
+# each process's CWD, and the subprocesses the runner tests spawn all run with cwd=tmp_path - a bare `.`
+# there means "measure the temp directory", which silently measures nothing of ours. tests/conftest.py sets
+# the variable to the repo root when, and only when, it is propagating coverage into those children; a
+# plain `coverage run` from the repo root is unaffected and still gets `.`.
+source = ${SIDEWALK_COVERAGE_ROOT-.}
+
+# Branch coverage, not just lines. The motivating finding here was an `if` that only ever goes one way -
+# three of the log analyzer's six alert rules never fired in any test while every line around them was
+# green. It lowers the headline number; that is the point.
+branch = True
+
+# tests/test_download_runner.py and tests/test_crop_runner.py drive the runners as real subprocesses, and
+# tests/test_log_analyzer.py runs a copy of analyze.py the same way. pytest-cov starts coverage inside those
+# children via its own .pth; parallel keeps their data files from clobbering the parent's, and pytest-cov
+# combines them before reporting. Without it, main(), the argparse type= validators and the budget
+# carve-out all read as dead code and the number sends you off writing tests that already exist.
+parallel = True
+
+omit =
+    tests/*
+    # Study/report tooling: a large body of frozen one-off analysis, densely tested in its own right
+    # (tests/test_*_study.py, test_*_census.py, ...). Measuring it here would let the nightly scraper's
+    # number move several points without anyone seeing it.
+    reports/*
+    # A 2022 one-off from the depth-endpoint outage whose module scope opens files and writes CSVs at
+    # import. It cannot be imported, let alone measured.
+    flag_panos/*
+    # Builds the README's hero figure (assets/make_banner.py). Tooling about the repo rather than part
+    # of the scraper, tested in its own right by tests/test_make_banner.py, and averaging it in would
+    # move the production number for a reason no operator cares about.
+    assets/*
+    # Agent worktrees live under .claude/worktrees/<branch>/ inside the primary checkout - without this a
+    # `pytest --cov` run from there would walk a full second copy of the repo.
+    .claude/*
+    venv/*
+    .venv/*
+
+[report]
+show_missing = True
+precision = 1
+
+# exclude_also, not exclude_lines: exclude_lines REPLACES coverage's own default list (`# pragma: no
+# cover`), and silently dropping that default is exactly the quiet misconfiguration a gate exists to stop.
+exclude_also =
+    if __name__ == .__main__.:
+
+# A ratchet, not a target. It exists to catch a deleted test file or a new unmeasured module, not to turn
+# every PR into a coverage negotiation. Set from the measured number, never lowered, raised only by the PR
+# that earns it. 95 against a measured 96.2% on a Windows dev box. Three posix_only file-mode assertions
+# skip there and run on CI, so CI's figure is never the lower of the two - though not necessarily the
+# higher either: they assert modes on files other tests already wrote, so they reach no new lines.
+# (The eight SIDEWALK_LIVE_TILE_TESTS skips are opt-in everywhere, CI included.)
+fail_under = 95

--- a/.coveragerc
+++ b/.coveragerc
@@ -59,8 +59,19 @@ exclude_also =
 
 # A ratchet, not a target. It exists to catch a deleted test file or a new unmeasured module, not to turn
 # every PR into a coverage negotiation. Set from the measured number, never lowered, raised only by the PR
-# that earns it. 95 against a measured 96.2% on a Windows dev box. Three posix_only file-mode assertions
-# skip there and run on CI, so CI's figure is never the lower of the two - though not necessarily the
-# higher either: they assert modes on files other tests already wrote, so they reach no new lines.
+# that earns it. 98 against a measured 99.4% on a Windows dev box - and 99.4% on CI too: three posix_only
+# file-mode assertions skip here and run there, so CI's figure is never the lower of the two, but they
+# assert modes on files other tests already wrote, so they reach no new lines and it is not higher either.
 # (The eight SIDEWALK_LIVE_TILE_TESTS skips are opt-in everywhere, CI included.)
-fail_under = 95
+#
+# The remainder is enumerable rather than unknown, and nothing here carries a `# pragma: no cover`, because
+# a pragma is a claim:
+#   - gsv.py's `except ImportError` fallback for depth_min_request_interval. Real deployment behaviour (the
+#     scraper box carries local edits to config.py), but gsv uses relative imports, so it cannot be
+#     re-executed against a stub config the way analyze.py can.
+#   - gsv.py's `_get_response(stream=False)` arm: a dead affordance whose fix is deletion, not a test.
+#   - gsv.py's photometa early return for a message carrying no depth planes.
+#   - DownloadRunner's fallback_success counter arm: no code path in the suite produces that verdict.
+#   - three partial branches that need an input no caller produces - mapillary's falsy-chunk skip, and
+#     analyze.py's two loop guards.
+fail_under = 98

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,4 +18,14 @@ jobs:
           python-version: '3.10'
           cache: pip
       - run: pip install -r requirements.txt -r requirements-dev.txt
-      - run: python -m pytest tests -v
+      # Bare --cov takes its source and omissions from .coveragerc, so there is one place to change them.
+      # skip-covered keeps the (already -v, 1400-test) log readable; the step summary below is not skipped,
+      # so the PR view still shows every file including the ones at 100%.
+      - run: python -m pytest tests -v --cov --cov-report=term-missing:skip-covered
+      # always(), so a run that trips the fail_under gate still shows WHERE it lost coverage rather than
+      # just failing. --fail-under=0 because the pytest step above is the gate; this step only reports.
+      - name: Coverage summary
+        if: always()
+        run: |
+          echo '## Coverage' >> "$GITHUB_STEP_SUMMARY"
+          python -m coverage report --format=markdown --fail-under=0 >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,13 @@ venv
 crop.log.bak.txt
 .idea
 cropsbak
+# Coverage data. The .coverage.* forms are the per-process files `parallel = True` produces - one per test
+# subprocess - which are combined into .coverage and would otherwise pile up after an interrupted run.
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+
 # Logs the analyzer pulls off the pano store - a local cache, re-downloadable on every run.
 log_analyzer/logs/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ Tests:
 ```bash
 pip3 install -r requirements.txt -r requirements-dev.txt
 python3 -m pytest tests
+python3 -m pytest tests --cov --cov-report=term-missing   # what CI reports and gates on
 ```
 
 CI (`.github/workflows/tests.yml`) runs the suite on Ubuntu 22.04 / Python 3.10, the production baseline. There is no linter configured.
@@ -59,6 +60,12 @@ The README is a front door only; the reference material lives in `docs/` and eac
 | `docs/history.md` | removed code, and why |
 
 `tests/test_docs.py` fails if a relative link or an anchor (cross-page **or** same-page) stops resolving, if a docs page is not linked from the README, or if a `docs/*.md` path cited in a Python comment **or in this file** goes missing — so the pointers above are checked, not decorative. Links are scanned over the joined page text, so one that hard-wraps across a newline is still checked.
+
+**Coverage** is configured in `.coveragerc` (#57) and gated by its `fail_under`. Three things about it are load-bearing and easy to break by "simplifying":
+
+- **The measured set is the production tree only** — the nine top-level/`downloaders/`/`log_analyzer/` modules. `reports/*` and `flag_panos/*` are omitted, the first because averaging a large body of frozen study tooling in would let the scraper's number move several points unnoticed, the second because its module scope writes files at import. `tests/test_coverage_config.py` asserts the resolved set exactly, so adding a module is a deliberate measure-or-omit decision.
+- **`source` is written as `${SIDEWALK_COVERAGE_ROOT-.}`, not `.`** — coverage resolves a relative source against each *process's* CWD, and the runner tests spawn subprocesses with `cwd=tmp_path`. `tests/conftest.py`'s `pytest_configure` sets that variable (plus `COVERAGE_PROCESS_START` and `COVERAGE_FILE`) only when the parent is itself being measured. Break any of the three and `main()`, the argparse `type=` validators and the budget carve-out all read as dead: `DownloadRunner.py` drops from 97.6% to 87.9% with nothing failing.
+- **`branch = True`** — the gap that motivated the gate was an `if` that only ever went one way (three of the log analyzer's six alert rules never fired while every line around them was green).
 
 ## Architecture
 
@@ -281,7 +288,7 @@ See `docs/api-fields.md` for the full field glossary for `/adminapi/panos` and `
 
 ## Other directories
 
-- `tests/` — pytest suite (network-free; `streetlevel` is stubbed). Covers the depth phase, the `log.csv` contract, the log analyzer, the depth migrator, the docs' internal links (`test_docs.py`), the README's hero figure (`test_make_banner.py`), the three file intakes as one contract (`test_csv_intake.py`), and the cropper (`test_crop_runner.py`: intake, the crop loop's failure taxonomy and count reconciliation, `predict_crop_size` pins). `test_streetlevel_api.py` imports the real `streetlevel` to pin API details and skips itself if it isn't installed.
+- `tests/` — pytest suite (network-free; `streetlevel` is stubbed). Covers the depth phase, the `log.csv` contract, the log analyzer, the depth migrator, the docs' internal links (`test_docs.py`), the README's hero figure (`test_make_banner.py`), the three file intakes as one contract (`test_csv_intake.py`), and the cropper (`test_crop_runner.py`: intake, the crop loop's failure taxonomy and count reconciliation, `predict_crop_size` pins). `test_streetlevel_api.py` imports the real `streetlevel` to pin API details and skips itself if it isn't installed. `test_coverage_config.py` pins `.coveragerc` itself — the measured set, and the settings whose loss shows up as a lower number rather than an error.
 - `log_analyzer/` — the log analyzer plus `cities.csv`; `log_analyzer/logs/` is a gitignored local cache.
 - `flag_panos/` — one-off web tool (HTML/JS) from the 2022 depth-endpoint outage. Not wired into the Python scripts; keep unless asked.
 - `samples/` — reference CSV/JSON/XML and a sample pano+crop used for manual testing and as examples for the `-c`/`-f` flags.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3,10 +3,34 @@
 ```bash
 pip3 install -r requirements.txt -r requirements-dev.txt
 python3 -m pytest tests
+
+# ... with the coverage report CI publishes and gates on
+python3 -m pytest tests --cov --cov-report=term-missing
 ```
 
 CI runs exactly this on Ubuntu 22.04 / Python 3.10 for every push to `master` and every pull request
 ([`.github/workflows/tests.yml`](../.github/workflows/tests.yml)). There is no linter configured.
+
+## Coverage
+
+CI reports coverage on every run and fails the build below the `fail_under` floor in
+[`.coveragerc`](../.coveragerc) ([#57](https://github.com/ProjectSidewalk/sidewalk-panorama-tools/issues/57)).
+The measured set is the production tree only — the nine modules at the repo root, in `downloaders/` and in
+`log_analyzer/`. `reports/` is deliberately outside it: a large body of frozen one-off analysis with its own
+dense tests, and averaging it in would let the scraper's number move several points unnoticed. `flag_panos/`
+is out because its module scope writes files at import, and `assets/` is out because building the hero
+figure is tooling about the repo rather than part of the scraper. `tests/test_coverage_config.py` pins that set exactly,
+so adding a module is a deliberate measure-or-omit decision rather than silently either.
+
+Two settings there are load-bearing, and losing either shows up as a *lower number* rather than as an error:
+
+- **`branch = True`** — the gap that motivated the gate was an `if` that only ever went one way (three of the
+  log analyzer's six alert rules never fired while every line around them was green).
+- **`source = ${SIDEWALK_COVERAGE_ROOT-.}`, not `.`** — coverage resolves a relative source against each
+  *process's* CWD, and the runner tests spawn subprocesses with `cwd=tmp_path`. That variable, plus
+  `COVERAGE_PROCESS_START` and `COVERAGE_FILE`, is set by `tests/conftest.py`'s `pytest_configure`, and only
+  when the parent is itself being measured. Break any of the three and `main()`, the argparse `type=`
+  validators and the budget carve-out all read as dead code while nothing fails.
 
 ## What the suite covers
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,10 @@
 pytest>=7
+# Coverage is measured and gated in CI (#57); see .coveragerc. pytest-cov drives it; coverage is named
+# directly because the CI summary step calls `coverage report` on its own. >=7.4 for `exclude_also` (7.2)
+# and `coverage report --format=markdown` (7.0); tests/conftest.py relies on the .pth that ships with it to
+# reach the subprocesses the runner tests spawn.
+pytest-cov>=5
+coverage>=7.4
 # The reports/ figure generators, and tests/test_off_target_markers_figures.py which drives them.
 # Not in requirements.txt: nothing the scraper or cropper runs in production imports it.
 matplotlib>=3.5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,38 @@ if REPO_ROOT not in sys.path:
 posix_only = pytest.mark.skipif(os.name != 'posix', reason='POSIX file modes are unavailable on Windows')
 
 
+def pytest_configure(config):
+    """Extend coverage into the subprocesses several test modules spawn (#57).
+
+    The runners are driven as real subprocesses - `main()`, the argparse `type=` validators, the budget
+    carve-out prints and both `__main__` guards only ever execute in a child - so without this the coverage
+    report calls a few hundred well-tested lines dead and sends the next person off writing tests that
+    already exist. That is a worse failure than having no number at all.
+
+    coverage ships a .pth that measures any interpreter it starts in, but only when COVERAGE_PROCESS_START
+    names a config file; pytest-cov does not set it. So set it here, and only when this process is itself
+    being measured - otherwise every subprocess in an ordinary run would litter .coverage.* files. The
+    children inherit it because the helpers spawn with `dict(os.environ, ...)` rather than a scrubbed env.
+
+    `parallel = True` in .coveragerc is the other half: without it each child would overwrite the parent's
+    data file instead of adding to it.
+    """
+    if os.environ.get('COVERAGE_PROCESS_START'):
+        return
+    try:
+        import coverage
+    except ImportError:
+        return
+    if coverage.Coverage.current() is not None:
+        os.environ['COVERAGE_PROCESS_START'] = os.path.join(REPO_ROOT, '.coveragerc')
+        # The other two halves of the same CWD problem, because every one of these helpers spawns with
+        # cwd=tmp_path: coverage resolves both the data file and a relative `source` against the running
+        # process's CWD. Without the first the children measure correctly and then drop their data in a
+        # directory pytest deletes; without the second they measure the temp directory instead of the repo.
+        os.environ['COVERAGE_FILE'] = os.path.join(REPO_ROOT, '.coverage')
+        os.environ['SIDEWALK_COVERAGE_ROOT'] = REPO_ROOT
+
+
 @pytest.fixture
 def fake_streetview(monkeypatch):
     """Install a stub streetlevel.streetview module and return it for per-test find_panorama_by_id stubbing.

--- a/tests/test_coverage_config.py
+++ b/tests/test_coverage_config.py
@@ -1,0 +1,138 @@
+"""Tests for .coveragerc — the settings the CI coverage gate depends on (#57).
+
+Nothing here measures coverage; these pin the *configuration*, because every way this setup fails is quiet.
+`source` plus `omit` decides which files the number is an average over, and a directory that silently joins
+or leaves that set moves the headline figure without moving any test. Three of the settings are load-bearing
+in a way that is not obvious from reading them, so each gets a test that says why.
+"""
+
+import configparser
+import fnmatch
+import os
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+COVERAGERC = os.path.join(REPO_ROOT, '.coveragerc')
+
+# The files the gate is an average over. Adding a production module means adding it here too - that is the
+# point: a new module has to be a deliberate decision to measure or to omit, not a default of invisibility.
+PRODUCTION_MODULES = {
+    'CropRunner.py',
+    'DownloadRunner.py',
+    'config.py',
+    'downloaders/__init__.py',
+    'downloaders/common.py',
+    'downloaders/gsv.py',
+    'downloaders/mapillary.py',
+    'log_analyzer/analyze.py',
+    'migrate_depth_artifacts.py',
+}
+
+# Walked but never measured, and not worth listing in .coveragerc's omit: no .py lives under them.
+_PRUNE_DIRS = {'.git', '__pycache__', '.pytest_cache'}
+
+
+@pytest.fixture(scope='module')
+def cfg():
+    parser = configparser.ConfigParser()
+    read = parser.read(COVERAGERC)
+    assert read, f'.coveragerc not found at {COVERAGERC}'
+    return parser
+
+
+def omit_patterns(cfg):
+    return [line.strip() for line in cfg['run']['omit'].splitlines()
+            if line.strip() and not line.strip().startswith('#')]
+
+
+def is_omitted(relpath, patterns):
+    """Whether coverage would drop relpath, the way coverage matches omit: fnmatch, where * spans separators."""
+    return any(fnmatch.fnmatch(relpath, pattern) for pattern in patterns)
+
+
+def measured_files(patterns):
+    """Every .py under the repo that the omit list does not drop, as forward-slash relative paths."""
+    found = set()
+    for dirpath, dirnames, filenames in os.walk(REPO_ROOT):
+        dirnames[:] = [d for d in dirnames if d not in _PRUNE_DIRS]
+        for name in filenames:
+            if not name.endswith('.py'):
+                continue
+            rel = os.path.relpath(os.path.join(dirpath, name), REPO_ROOT).replace(os.sep, '/')
+            if not is_omitted(rel, patterns):
+                found.add(rel)
+    return found
+
+
+class TestEveryProductionModuleIsMeasured:
+    """`source = .` minus `omit` must resolve to exactly the set we think it does.
+
+    The failure this prevents is not a red build, it is a green one: drop a directory into the repo and the
+    coverage figure starts averaging over files nobody chose to measure, or stops averaging over files
+    everybody assumed were measured. Neither shows up as a test failure anywhere else.
+    """
+
+    def test_the_measured_set_is_exactly_the_production_modules(self, cfg):
+        measured = measured_files(omit_patterns(cfg))
+        assert measured == PRODUCTION_MODULES, (
+            'The set of files .coveragerc measures has changed.\n'
+            f'  newly measured: {sorted(measured - PRODUCTION_MODULES)}\n'
+            f'  no longer measured: {sorted(PRODUCTION_MODULES - measured)}\n'
+            'Add the file to PRODUCTION_MODULES above if it should count toward the gate, or to '
+            '.coveragerc\'s omit list if it should not. Do not "fix" this by deleting the assertion.')
+
+    def test_the_check_would_fail_on_an_unlisted_module(self, cfg):
+        """Guard the guard: the walk must actually flag a file no omit pattern covers.
+
+        Without this, an omit list that accidentally matched everything would leave the test above comparing
+        an empty set against an empty set and passing forever.
+        """
+        patterns = omit_patterns(cfg)
+        assert not is_omitted('a_new_scraper.py', patterns)
+        assert not is_omitted('newpackage/thing.py', patterns)
+        # ... while the things we do omit stay omitted, so the matcher is not simply always-False.
+        assert is_omitted('tests/test_docs.py', patterns)
+        assert is_omitted('reports/scripts/rawlabels.py', patterns)
+        assert is_omitted('flag_panos/json_to_csv.py', patterns)
+        assert is_omitted('assets/make_banner.py', patterns)
+
+
+class TestTheSettingsThatMakeSubprocessCoverageWork:
+    """Three settings whose removal shows up as a *lower* number, not as an error (#57).
+
+    The runners are driven as real subprocesses, so main(), the argparse type= validators and the budget
+    carve-out only ever execute in a child. Measured with these on, DownloadRunner.py reads 97.6%; with
+    subprocess capture broken it reads 87.9% and seven well-tested ranges look dead. Someone chasing that
+    would write tests that already exist.
+    """
+
+    def test_parallel_is_on_so_children_do_not_clobber_the_parents_data(self, cfg):
+        assert cfg['run'].getboolean('parallel') is True
+
+    def test_source_survives_a_child_running_in_another_directory(self, cfg):
+        """The subprocess helpers all spawn with cwd=tmp_path, and coverage resolves a relative source
+        against each process's own CWD - so a bare `.` here means the children measure the temp directory.
+        tests/conftest.py sets SIDEWALK_COVERAGE_ROOT to the repo root for exactly this reason.
+        """
+        source = cfg['run']['source'].strip()
+        assert source == '${SIDEWALK_COVERAGE_ROOT-.}', (
+            f'source is {source!r}. A bare "." silently measures tmp_path in every test subprocess; see '
+            'pytest_configure in tests/conftest.py.')
+
+    def test_branch_coverage_is_on(self, cfg):
+        """The finding that motivated the gate was an `if` that only ever went one way - three of the log
+        analyzer's six alert rules never fired while every line around them was green."""
+        assert cfg['run'].getboolean('branch') is True
+
+
+class TestTheGateIsActuallyArmed:
+
+    def test_fail_under_is_set(self, cfg):
+        """A fail_under of 0 is the same as no gate, and reads like one that is working."""
+        assert cfg['report'].getfloat('fail_under') > 0
+
+    def test_exclude_also_is_used_rather_than_exclude_lines(self, cfg):
+        """exclude_lines REPLACES coverage's own default (`# pragma: no cover`); exclude_also adds to it."""
+        assert 'exclude_lines' not in cfg['report']
+        assert 'exclude_also' in cfg['report']

--- a/tests/test_crop_runner.py
+++ b/tests/test_crop_runner.py
@@ -13,6 +13,7 @@ into a tmp store with the production <pano_id[:2]>/<pano_id>.jpg sharding.
 import csv
 import json
 import logging
+import logging.handlers  # not implied by `import logging`; asserted on below
 import os
 import subprocess
 import sys
@@ -1295,3 +1296,127 @@ class TestCoordinateBounds:
         counts = crop_runner.bulk_extract_crops([label_row()], str(store), str(out))
         assert counts['success'] == 1
         assert counts['shifted_vertically'] == 0
+
+
+# ---------------------------------------------------------------------------
+# Process setup and the single-crop entry point
+# ---------------------------------------------------------------------------
+
+class TestAnUnopenableLogFallsBackToStderr:
+    """crop.log is the run's only record under cron. Not being able to open it must cost the log, not the
+    run - a store whose crops are already cut is exactly when the log is least worth failing over.
+
+    DownloadRunner's twin of this is already covered by its subprocess test; CropRunner's had nothing.
+    """
+
+    def test_the_run_falls_back_to_a_stream_handler(self, crop_runner, tmp_path, caplog):
+        # A directory cannot be opened as a file on any OS, which is how test_download_runner provokes the
+        # same branch without needing permissions that differ between platforms.
+        log_path = tmp_path / 'crop.log'
+        log_path.mkdir()
+        root = logging.getLogger()
+        before = list(root.handlers)
+
+        crop_runner.configure_logging(str(log_path))
+
+        added = [h for h in root.handlers if h not in before]
+        assert len(added) == 1
+        assert isinstance(added[0], logging.StreamHandler)
+        assert not isinstance(added[0], logging.handlers.RotatingFileHandler)
+        assert list(log_path.iterdir()) == [], 'nothing should have been written into the directory'
+
+    def test_the_operator_is_told_where_the_log_went(self, crop_runner, tmp_path, caplog):
+        """Silently redirecting to stderr is worse than the failure: under cron stderr goes to mail and then
+        nowhere, so a run whose log 'just stopped appearing' has no explanation on disk."""
+        log_path = tmp_path / 'crop.log'
+        log_path.mkdir()
+
+        with caplog.at_level(logging.WARNING):
+            crop_runner.configure_logging(str(log_path))
+
+        assert 'logging to stderr' in caplog.text
+        assert str(log_path) in caplog.text
+
+    def test_a_writable_path_still_gets_a_rotating_file_handler(self, crop_runner, tmp_path):
+        """Guard the guard: the fallback must be a fallback, not what every run gets."""
+        root = logging.getLogger()
+        before = list(root.handlers)
+
+        crop_runner.configure_logging(str(tmp_path / 'crop.log'))
+
+        added = [h for h in root.handlers if h not in before]
+        assert [type(h) for h in added] == [logging.handlers.RotatingFileHandler]
+
+
+class TestMetadataSourceDispatch:
+    """load_label_metadata's -d arm. The .csv, .json and unknown-extension arms are pinned elsewhere in this
+    file; the server arm is the one nothing reached."""
+
+    def test_no_file_means_the_server(self, crop_runner, monkeypatch):
+        asked = []
+        monkeypatch.setattr(crop_runner, 'fetch_cvMetadata_from_server',
+                            lambda fqdn: asked.append(fqdn) or [{'label_id': 1}])
+        for name in ('fetch_label_ids_csv', 'fetch_cvMetadata_from_file'):
+            monkeypatch.setattr(crop_runner, name, lambda *a, **k: pytest.fail('wrong intake: ' + name))
+
+        rows = crop_runner.load_label_metadata('sidewalk-test.invalid', None)
+
+        assert asked == ['sidewalk-test.invalid']
+        assert rows == [{'label_id': 1}]
+
+
+class TestMakeSingleCropAcceptsAPath:
+    """make_single_crop's path form, kept for one-off use outside the pano-grouped bulk loop.
+
+    bulk_extract_crops always hands it an already-open Image, so the two lines that open a path and the one
+    that closes it were never executed by anything.
+    """
+
+    def test_a_path_and_an_open_image_produce_the_same_crop(self, crop_runner, tmp_path):
+        store = tmp_path / 'store'
+        put_pano(store, 'testpano0001', square_at=(200, INTERIOR_Y))
+        pano_path = os.path.join(str(store), 'te', 'testpano0001.jpg')
+
+        from_path = str(tmp_path / 'from_path.jpg')
+        from_image = str(tmp_path / 'from_image.jpg')
+        box_a = crop_runner.make_single_crop(pano_path, 200, INTERIOR_Y, from_path)
+        with Image.open(pano_path) as pano:
+            box_b = crop_runner.make_single_crop(pano, 200, INTERIOR_Y, from_image)
+
+        assert box_a == box_b
+        assert open(from_path, 'rb').read() == open(from_image, 'rb').read()
+
+    def test_an_image_opened_from_a_path_is_closed_again(self, crop_runner, tmp_path, monkeypatch):
+        """A 16384x8192 pano is a few hundred MB decoded. Leaking one per call is survivable in a one-off
+        script and is not survivable in a loop, which is precisely what this form invites."""
+        store = tmp_path / 'store'
+        put_pano(store, 'testpano0001')
+        pano_path = os.path.join(str(store), 'te', 'testpano0001.jpg')
+
+        opened = []
+        real_open = Image.open
+
+        def recording_open(fp, *args, **kwargs):
+            image = real_open(fp, *args, **kwargs)
+            opened.append(image)
+            return image
+
+        monkeypatch.setattr(Image, 'open', recording_open)
+        crop_runner.make_single_crop(pano_path, 200, INTERIOR_Y, str(tmp_path / 'crop.jpg'))
+
+        assert len(opened) == 1
+        assert opened[0].fp is None, 'the pano this call opened was left open'
+
+    def test_an_image_handed_in_is_left_open_for_its_other_labels(self, crop_runner, tmp_path):
+        """The other half of the same branch: the bulk loop decodes each pano once and cuts every label on
+        it, so closing a caller's image would break the label after this one."""
+        store = tmp_path / 'store'
+        put_pano(store, 'testpano0001')
+        pano_path = os.path.join(str(store), 'te', 'testpano0001.jpg')
+
+        with Image.open(pano_path) as pano:
+            crop_runner.make_single_crop(pano, 200, INTERIOR_Y, str(tmp_path / 'first.jpg'))
+            # Still usable: this is what the second label on the same pano depends on.
+            crop_runner.make_single_crop(pano, 400, INTERIOR_Y, str(tmp_path / 'second.jpg'))
+
+        assert os.path.exists(str(tmp_path / 'second.jpg'))

--- a/tests/test_crop_runner.py
+++ b/tests/test_crop_runner.py
@@ -1393,19 +1393,34 @@ class TestMakeSingleCropAcceptsAPath:
         put_pano(store, 'testpano0001')
         pano_path = os.path.join(str(store), 'te', 'testpano0001.jpg')
 
+        # A proxy that records close(), rather than inspecting the image afterwards: PIL drops `.fp` as soon
+        # as the pixels are loaded, which crop() forces, so `fp is None` is true whether or not anything
+        # ever called close(). It reads like a leak check and is not one.
+        class RecordingImage:
+            def __init__(self, image):
+                self._image = image
+                self.closed = False
+
+            def __getattr__(self, name):
+                return getattr(self._image, name)
+
+            def close(self):
+                self.closed = True
+                self._image.close()
+
         opened = []
         real_open = Image.open
 
         def recording_open(fp, *args, **kwargs):
-            image = real_open(fp, *args, **kwargs)
-            opened.append(image)
-            return image
+            proxy = RecordingImage(real_open(fp, *args, **kwargs))
+            opened.append(proxy)
+            return proxy
 
         monkeypatch.setattr(Image, 'open', recording_open)
         crop_runner.make_single_crop(pano_path, 200, INTERIOR_Y, str(tmp_path / 'crop.jpg'))
 
         assert len(opened) == 1
-        assert opened[0].fp is None, 'the pano this call opened was left open'
+        assert opened[0].closed, 'the pano this call opened was left open'
 
     def test_an_image_handed_in_is_left_open_for_its_other_labels(self, crop_runner, tmp_path):
         """The other half of the same branch: the bulk loop decodes each pano once and cuts every label on

--- a/tests/test_download_runner.py
+++ b/tests/test_download_runner.py
@@ -1113,19 +1113,23 @@ class TestEveryDownloadResultLandsInItsOwnCounter:
     def test_each_verdict_is_counted_in_its_own_slot(self, monkeypatch, tmp_path):
         storage = tmp_path / 'storage'
         storage.mkdir()
-        ids = ['pano-success', 'pano-fallback', 'pano-skipped', 'pano-failure']
-        monkeypatch.setattr(DownloadRunner, 'download_pano', self.scripted_download_pano({
-            'pano-success': downloaders.DownloadResult.success,
-            'pano-fallback': downloaders.DownloadResult.fallback_success,
-            'pano-skipped': downloaders.DownloadResult.skipped,
-            'pano-failure': downloaders.DownloadResult.failure,
-        }))
+        # A DIFFERENT number of each verdict, deliberately. One of each would make every transposition
+        # invisible - all four counters would read 1 and the tuple would be (1, 1, 1, 1, 4) whichever way
+        # they were wired. These multiplicities make the returned tuple unique to the correct wiring.
+        verdicts, panos = {}, []
+        for verdict, count in ((downloaders.DownloadResult.success, 1),
+                               (downloaders.DownloadResult.fallback_success, 2),
+                               (downloaders.DownloadResult.skipped, 3),
+                               (downloaders.DownloadResult.failure, 4)):
+            for n in range(count):
+                pano_id = 'pano-%s-%d' % (verdict, n)
+                verdicts[pano_id] = verdict
+                panos.append({'pano_id': pano_id, 'source': 'gsv'})
+        monkeypatch.setattr(DownloadRunner, 'download_pano', self.scripted_download_pano(verdicts))
 
-        result = DownloadRunner.download_panorama_images(
-            str(storage), [{'pano_id': p, 'source': 'gsv'} for p in ids])
+        result = DownloadRunner.download_panorama_images(str(storage), panos)
 
-        # One of each, so any pair of counters swapped in the returned tuple shows up here.
-        assert result == (1, 1, 1, 1, 4), \
+        assert result == (1, 2, 4, 3, 10), \
             'expected (success, fallback_success, fail, skipped, total)'
 
     def test_a_transient_error_is_counted_but_left_out_of_the_ledger(self, monkeypatch, tmp_path):

--- a/tests/test_download_runner.py
+++ b/tests/test_download_runner.py
@@ -1088,3 +1088,128 @@ def test_runtime_budget_arguments_are_passed_by_keyword():
         keywords = {kw.arg for kw in call.keywords}
         assert 'run_start_monotonic' in keywords, name
         assert 'max_runtime_minutes' in keywords, name
+
+
+class TestEveryDownloadResultLandsInItsOwnCounter:
+    """The five-tuple download_panorama_images returns, and which verdicts get a terminal ledger row.
+
+    That tuple is written straight into log.csv fields 7-11, which log_analyzer reads *positionally* - its
+    failure-growth check reads image_fail and its zero-progress check sums image_success and
+    image_fallback_success. So a transposition here is invisible in the scraper (the totals still add up)
+    and silently corrupts the ops signal for every city. The trap is real: the counters are initialised in
+    one order and returned in another.
+    """
+
+    @staticmethod
+    def scripted_download_pano(verdicts):
+        """Return a download_pano stand-in that answers by pano_id, with no network and no disk."""
+        def fake(storage_path, pano_info):
+            verdict = verdicts[pano_info['pano_id']]
+            if isinstance(verdict, Exception):
+                raise verdict
+            return verdict
+        return fake
+
+    def test_each_verdict_is_counted_in_its_own_slot(self, monkeypatch, tmp_path):
+        storage = tmp_path / 'storage'
+        storage.mkdir()
+        ids = ['pano-success', 'pano-fallback', 'pano-skipped', 'pano-failure']
+        monkeypatch.setattr(DownloadRunner, 'download_pano', self.scripted_download_pano({
+            'pano-success': downloaders.DownloadResult.success,
+            'pano-fallback': downloaders.DownloadResult.fallback_success,
+            'pano-skipped': downloaders.DownloadResult.skipped,
+            'pano-failure': downloaders.DownloadResult.failure,
+        }))
+
+        result = DownloadRunner.download_panorama_images(
+            str(storage), [{'pano_id': p, 'source': 'gsv'} for p in ids])
+
+        # One of each, so any pair of counters swapped in the returned tuple shows up here.
+        assert result == (1, 1, 1, 1, 4), \
+            'expected (success, fallback_success, fail, skipped, total)'
+
+    def test_a_transient_error_is_counted_but_left_out_of_the_ledger(self, monkeypatch, tmp_path):
+        """The #41 split. A permanent failure writes a terminal downloaded=0 row and is never retried; a
+        raised exception writes no row at all, so the pano comes back next run."""
+        storage = tmp_path / 'storage'
+        storage.mkdir()
+        monkeypatch.setattr(DownloadRunner, 'download_pano', self.scripted_download_pano({
+            'pano-permanent': downloaders.DownloadResult.failure,
+            'pano-transient': ConnectionError('connection reset'),
+        }))
+
+        result = DownloadRunner.download_panorama_images(
+            str(storage), [{'pano_id': p, 'source': 'gsv'} for p in ('pano-permanent', 'pano-transient')])
+
+        assert result == (0, 0, 2, 0, 2), 'both are this run’s failures'
+        ledger = (storage / 'pano_id_log.csv').read_text()
+        assert 'pano-permanent,0' in ledger
+        assert 'pano-transient' not in ledger, 'a transient failure must not be ledgered'
+
+    def test_a_duplicate_id_is_attempted_and_ledgered_once(self, monkeypatch, tmp_path):
+        """candidates is already filtered against the ledger, so this guard only catches a duplicate that
+        survived intake - which would otherwise be downloaded twice and written to the ledger twice, making
+        the ledger's own counts disagree with the store."""
+        storage = tmp_path / 'storage'
+        storage.mkdir()
+        calls = []
+        monkeypatch.setattr(DownloadRunner, 'download_pano', recording_download_pano(calls))
+
+        result = DownloadRunner.download_panorama_images(
+            str(storage), [{'pano_id': 'pano-twice', 'source': 'gsv'}] * 2)
+
+        assert calls == ['pano-twice']
+        assert result == (1, 0, 0, 0, 1)
+        assert (storage / 'pano_id_log.csv').read_text().count('pano-twice') == 1
+
+
+class TestAServerFetchIsCheckedAndNormalised:
+    """fetch_pano_ids_from_webserver's two failure-shaped responses.
+
+    test_pano_list_fetch_session_configuration above stops the request before it returns, so nothing
+    exercised what happens to a response that actually arrives.
+    """
+
+    @staticmethod
+    def respond(monkeypatch, status_code, payload=None):
+        class _Response:
+            def __init__(self):
+                self.status_code = status_code
+
+            def raise_for_status(self):
+                if self.status_code >= 400:
+                    raise requests.HTTPError('%s' % self.status_code, response=self)
+
+            def json(self):
+                return payload
+
+        monkeypatch.setattr(requests.Session, 'get', lambda self, url, **kwargs: _Response())
+
+    def test_a_server_error_raises_rather_than_returning_an_empty_corpus(self, monkeypatch):
+        """A 500 or a proxy error page must not read as "this city has no panos". The run would report a
+        clean night with zero work, and the log.csv row would be indistinguishable from a finished city.
+        """
+        self.respond(monkeypatch, 500)
+
+        with pytest.raises(requests.HTTPError):
+            DownloadRunner.fetch_pano_ids_from_webserver('sidewalk-test.invalid')
+
+    def test_numeric_and_duplicate_ids_are_normalised_on_the_server_path_too(self, monkeypatch):
+        """The #46 bug class. Mapillary ids are all-numeric, and JSON has no string/number distinction to
+        lean on - an int id here would be compared against the ledger's strings and never match, so the
+        pano would be re-downloaded every night forever.
+        """
+        self.respond(monkeypatch, 200, payload=[
+            {'pano_id': 123456789012345, 'source': 'mapillary'},
+            {'pano_id': '123456789012345', 'source': 'mapillary'},
+            {'pano_id': 'gsvPanoIdAAAAAAAAAAAAA', 'source': 'gsv'},
+            {'pano_id': '', 'source': 'gsv'},
+            {'pano_id': 'tutorial', 'source': 'gsv'},
+        ])
+
+        records = DownloadRunner.fetch_pano_ids_from_webserver('sidewalk-test.invalid')
+
+        ids = [r['pano_id'] for r in records]
+        assert all(isinstance(i, str) for i in ids), ids
+        assert ids == ['123456789012345', 'gsvPanoIdAAAAAAAAAAAAA'], \
+            'the numeric duplicate, the empty id and the tutorial pano should all be gone'

--- a/tests/test_gsv_stitcher.py
+++ b/tests/test_gsv_stitcher.py
@@ -675,3 +675,112 @@ class TestDownloadSinglePano:
         stub_probe(monkeypatch, pick_zoom=-1)  # every probe zoom comes back blank
 
         assert gsv.download_single_pano(str(tmp_path), self.pano_info()) == DownloadResult.failure
+
+
+class TestTheTileFanOutContract:
+    """`_download_tiles` itself - the aiohttp session and gather that every stitch runs through.
+
+    Everything else in this file stubs it out, so its own three promises had nothing holding them: the
+    concurrency cap comes from config, failures arrive as objects rather than propagating, and results stay
+    in the order they were asked for. The last two are what `_partition_tile_results` is built on (#45), and
+    the first is the only thing bounding how hard the fleet hits Google.
+    """
+
+    @pytest.fixture
+    def fake_aiohttp(self, monkeypatch):
+        """Stand-ins for TCPConnector and ClientSession that record their construction and open no socket."""
+        built = {}
+
+        class FakeConnector:
+            def __init__(self, limit=None):
+                built['limit'] = limit
+                built['connector_built'] = self
+
+        class FakeClientSession:
+            def __init__(self, raise_for_status=None, connector=None):
+                built['raise_for_status'] = raise_for_status
+                built['connector'] = connector
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+        monkeypatch.setattr(gsv.aiohttp, 'TCPConnector', FakeConnector)
+        monkeypatch.setattr(gsv.aiohttp, 'ClientSession', FakeClientSession)
+        return built
+
+    @staticmethod
+    def stub_tile_fetch(monkeypatch, outcomes):
+        """Answer each (x, y, url) from `outcomes`, keyed by x. An Exception value is raised, not returned.
+
+        _download_tile is patched, not _fetch_tile: the backoff wrapper is built at import time and closed
+        over the original function, so patching _fetch_tile would leave the real one running (and retrying).
+        """
+        async def fake_download_tile(session, tile):
+            x, y, _url = tile
+            outcome = outcomes[x]
+            if isinstance(outcome, Exception):
+                raise outcome
+            return (x, y, outcome)
+
+        monkeypatch.setattr(gsv, '_download_tile', fake_download_tile)
+
+    def tiles(self, count):
+        return [(x, 0, 'https://example.invalid/tile?x=%d' % x) for x in range(count)]
+
+    def test_the_connector_carries_the_configured_concurrency_cap(self, monkeypatch, fake_aiohttp):
+        """gsv binds thread_count by value at import (`from config import ...`), so the patch point is
+        gsv.thread_count - patching config.thread_count changes nothing here."""
+        monkeypatch.setattr(gsv, 'thread_count', 3)
+        self.stub_tile_fetch(monkeypatch, {0: b'a', 1: b'b'})
+
+        asyncio.run(gsv._download_tiles(self.tiles(2)))
+
+        assert fake_aiohttp['limit'] == 3
+        assert fake_aiohttp['raise_for_status'] is True
+        # The capped connector is the one the session actually got - built and then not passed would leave
+        # the fan-out running on aiohttp's default limit of 100.
+        assert fake_aiohttp['connector'] is fake_aiohttp['connector_built']
+
+    def test_results_come_back_in_the_order_they_were_requested(self, monkeypatch, fake_aiohttp):
+        """_partition_tile_results zips the request list against this one, so position is what pairs a
+        failure with its grid cell. A successful tile carries its own (x, y) and would still paste in the
+        right place, but a failed one would be reported at another cell's coordinates - and those
+        coordinates are the whole content of the scrape.log line an operator has to act on.
+
+        asyncio.gather promises this; the test is here because _download_tiles is free to stop using it.
+        """
+        self.stub_tile_fetch(monkeypatch, {0: b'zero', 1: b'one', 2: b'two'})
+
+        results = asyncio.run(gsv._download_tiles(self.tiles(3)))
+
+        assert results == [(0, 0, b'zero'), (1, 0, b'one'), (2, 0, b'two')]
+
+    def test_a_failing_tile_arrives_as_an_object_and_the_rest_survive(self, monkeypatch, fake_aiohttp):
+        """The #45 invariant, at its own seam. One tile raising must not abort the gather: 511 good tiles
+        would be discarded and the pano retried in full, every night, for one bad cell.
+        """
+        boom = aiohttp.ClientError('tile 1 died')
+        self.stub_tile_fetch(monkeypatch, {0: b'zero', 1: boom, 2: b'two'})
+        tiles = self.tiles(3)
+
+        results = asyncio.run(gsv._download_tiles(tiles))
+
+        assert results[0] == (0, 0, b'zero')
+        assert results[2] == (2, 0, b'two')
+        assert results[1] is boom, 'the exception must be a value in the list, not raised'
+
+        # ... and the partitioner downstream reads it as a failure at the right cell rather than as a tile.
+        ok, failed = gsv._partition_tile_results(tiles, results)
+        assert [x for x, _y, _data in ok] == [0, 2]
+        assert failed == [((1, 0), boom)]
+
+
+class TestAnEmptyFanOutStillHasACellSize:
+
+    def test_no_tiles_yields_the_nominal_tile_size(self):
+        """`max()` over an empty sequence raises, which would turn a zero-tile fan-out from "mostly black,
+        refused by the black guard" into an unexplained ValueError with no pano id attached."""
+        assert gsv._stitch_cell_size([]) == (gsv.TILE_SIZE, gsv.TILE_SIZE)

--- a/tests/test_image_downloaders.py
+++ b/tests/test_image_downloaders.py
@@ -72,6 +72,21 @@ class TestAtomicOutputPath:
         assert not os.path.exists(final)
         assert not os.path.exists(final + '.part')
 
+    def test_a_part_file_that_was_never_created_does_not_mask_the_real_error(self, tmp_path):
+        """Failing before the first byte is written is the common case, not an exotic one: a 404, an expired
+        signed URL, or a full store all abort before the open. The cleanup's own os.remove then fails, and
+        if that FileNotFoundError escaped it would replace the real cause in scrape.log with a message about
+        a temp file - sending whoever reads it to look in entirely the wrong place.
+        """
+        final = str(tmp_path / 'pano.jpg')
+
+        with pytest.raises(RuntimeError, match='the actual cause'):
+            with atomic_output_path(final):
+                raise RuntimeError('the actual cause')
+
+        assert not os.path.exists(final)
+        assert not os.path.exists(final + '.part')
+
     @posix_only
     def test_the_renamed_file_is_group_writable(self, tmp_path):
         final = str(tmp_path / 'pano.jpg')
@@ -274,3 +289,152 @@ class TestGsvAtomicSave:
             downloaders.gsv.download_single_pano(str(tmp_path), GSV_PANO)
 
         assert os.listdir(tmp_path / 'gs') == [], "a stub .jpg would be read as done by every later run"
+
+
+class TestDownloadPanoRoutesBySource:
+    """`downloaders.download_pano` itself — the dispatcher whose docstring states the #41 contract the two
+    modules above are held to, and which nothing called with a real source string until #57.
+
+    Every test in this file goes through one downloader directly; the image loop goes through here.
+    """
+
+    @pytest.fixture
+    def recorded(self, monkeypatch):
+        """Replace both downloaders with recorders, so nothing here can reach a network or a disk."""
+        calls = []
+
+        def recorder(name, verdict):
+            def fake(storage_path, pano_info):
+                calls.append((name, storage_path, pano_info))
+                return verdict
+            return fake
+
+        monkeypatch.setattr(downloaders.gsv, 'download_single_pano',
+                            recorder('gsv', DownloadResult.success))
+        monkeypatch.setattr(downloaders.mapillary, 'download_single_pano',
+                            recorder('mapillary', DownloadResult.skipped))
+        return calls
+
+    def test_a_gsv_pano_reaches_gsv_with_its_arguments_intact(self, recorded):
+        result = downloaders.download_pano('/store', GSV_PANO)
+
+        assert recorded == [('gsv', '/store', GSV_PANO)]
+        assert result == DownloadResult.success
+
+    def test_a_mapillary_pano_reaches_mapillary(self, recorded):
+        result = downloaders.download_pano('/store', MAPILLARY_PANO)
+
+        assert recorded == [('mapillary', '/store', MAPILLARY_PANO)]
+        # The verdict is passed through untouched rather than re-derived - the ledger's whole contract is
+        # that the downloader decides permanence, not the dispatcher.
+        assert result == DownloadResult.skipped
+
+    def test_a_pano_with_no_source_field_defaults_to_gsv(self, recorded):
+        """The -c CSV intake is hand-made by operators and carries whatever columns they wrote; a pano with
+        no 'source' at all is the ordinary case there, not a malformed one."""
+        downloaders.download_pano('/store', {'pano_id': 'abcdefghijklmnopqrstuv'})
+
+        assert [name for name, _, _ in recorded] == ['gsv']
+
+    def test_an_unrecognised_source_raises_rather_than_ledgering_the_pano(self, recorded):
+        """A source we don't recognise is a property of OUR code - a new imagery type shipped by the server
+        before this repo learned about it - not a permanent property of the pano. Returning
+        DownloadResult.failure would ledger every such pano downloaded=0 and never look at them again, so a
+        few hours of deploy skew would permanently blacklist a whole city's corpus (#41).
+        """
+        with pytest.raises(ValueError) as excinfo:
+            downloaders.download_pano('/store', {'pano_id': 'x', 'source': 'bing'})
+
+        assert 'bing' in str(excinfo.value)
+        assert recorded == [], 'neither downloader should have been consulted'
+
+
+class TestMapillarySessionRetryPolicy:
+    """`_session()`'s adapter configuration, which is what stands between the fleet and Mapillary's 429s."""
+
+    def test_both_schemes_carry_the_retry_policy(self):
+        session = downloaders.mapillary._session()
+
+        for url in ('https://graph.mapillary.com/1', 'http://cdn.example/x.jpg'):
+            retries = session.get_adapter(url).max_retries
+            assert retries.total == 5
+            assert retries.connect == 5
+            assert set(retries.status_forcelist) >= {429, 500, 502, 503, 504}
+
+    def test_the_plain_http_scheme_is_mounted_too(self):
+        """Not redundant with the above: thumb_original_url is a short-lived signed CDN URL that this code
+        never inspects, so an http:// rendition (or a redirect through one) must keep the policy rather
+        than falling back to requests' default of no retries at all."""
+        session = downloaders.mapillary._session()
+
+        assert session.get_adapter('http://cdn.example/x.jpg') is \
+            session.get_adapter('https://cdn.example/x.jpg')
+
+
+class TestAnImageAlreadyOnDiskIsItsOwnResumeMarker:
+
+    def test_an_existing_jpg_is_skipped_before_the_token_or_the_network(self, monkeypatch, tmp_path):
+        """The skip has to come first. A resumed run over a fully-downloaded city must not need the token
+        set, and must not open a session per pano to discover it has nothing to do.
+        """
+        monkeypatch.delenv(downloaders.mapillary.TOKEN_ENV_VAR, raising=False)
+
+        def explode():
+            raise AssertionError('a pano already on disk must not build a session')
+
+        monkeypatch.setattr(downloaders.mapillary, '_session', explode)
+        shard = tmp_path / MAPILLARY_PANO['pano_id'][:2]
+        shard.mkdir()
+        (shard / (MAPILLARY_PANO['pano_id'] + '.jpg')).write_bytes(jpeg_bytes(80))
+
+        assert downloaders.mapillary.download_single_pano(str(tmp_path), MAPILLARY_PANO) \
+            == DownloadResult.skipped
+
+
+class TestALostShardDirRaceDoesNotFailThePano:
+    """Both downloaders chmod the shard directory they just created, and swallow PermissionError.
+
+    The pano store is shared: another user's scraper run can create the same shard a microsecond earlier,
+    and then the chmod is against their directory and fails. Letting that propagate would turn a harmless
+    race into a failed pano - and, on the GSV side, into a transient error retried every night forever.
+    Stubbing chmod rather than manipulating real modes keeps this meaningful on Windows too.
+    """
+
+    @staticmethod
+    def deny_chmod_on_directories(monkeypatch):
+        """Refuse chmod on directories only.
+
+        `module.os` is the one shared os module, so a blanket stub would also hit atomic_output_path's chmod
+        of the .part file and prove nothing about the shard-dir race. Directories are exactly what the race
+        is about, and it keeps the atomic write's own failure modes visible.
+        """
+        real_chmod = os.chmod
+
+        def refuse_directories(path, mode, *args, **kwargs):
+            if os.path.isdir(path):
+                raise PermissionError(1, 'Operation not permitted')
+            return real_chmod(path, mode, *args, **kwargs)
+
+        monkeypatch.setattr(os, 'chmod', refuse_directories)
+
+    def test_mapillary_still_downloads(self, monkeypatch, tmp_path, mapillary_token):
+        self.deny_chmod_on_directories(monkeypatch)
+        session = FakeSession(FakeResponse(payload={'thumb_original_url': 'https://cdn/x.jpg'}),
+                              FakeResponse(chunks=[jpeg_bytes(120)]))
+        monkeypatch.setattr(downloaders.mapillary, '_session', lambda: session)
+
+        assert downloaders.mapillary.download_single_pano(str(tmp_path), MAPILLARY_PANO) \
+            == DownloadResult.success
+
+    def test_gsv_still_downloads(self, monkeypatch, tmp_path):
+        tile = jpeg_bytes(120)
+        monkeypatch.setattr(downloaders.gsv, '_get_response',
+                            lambda url, session, stream=False: io.BytesIO(tile))
+
+        async def fake_download_tiles(tiles):
+            return [(x, y, tile) for x, y, _url in tiles]
+
+        monkeypatch.setattr(downloaders.gsv, '_download_tiles', fake_download_tiles)
+        self.deny_chmod_on_directories(monkeypatch)
+
+        assert downloaders.gsv.download_single_pano(str(tmp_path), GSV_PANO) == DownloadResult.success

--- a/tests/test_migrate_depth_artifacts.py
+++ b/tests/test_migrate_depth_artifacts.py
@@ -185,3 +185,64 @@ def test_unreadable_artifact_is_counted_failed_and_does_not_stop_the_run(tmp_pat
     assert read_bytes(corrupt) == b'this is not an npz'  # left for a human, not clobbered
     with np.load(good) as d:
         np.testing.assert_allclose(d['depth'], [[100.0, 2.0], [200.0, 3.0]])
+
+
+class TestAFailedRewriteLeavesTheOriginalArtifactIntact:
+    """The migrator rewrites in place, over a store this repo cannot regenerate cheaply - a depth artifact
+    costs one metadata request to Google and the backfill is a multi-month job. So the write goes through a
+    .part and a rename, and the cleanup has to hold for a failure at either side of the first byte.
+
+    Nothing exercised the failure path: every existing test writes successfully.
+    """
+
+    @staticmethod
+    def fail_during_save(monkeypatch, when):
+        """Make savez_compressed fail either after writing bytes, or before writing any."""
+        def failing(file, **kwargs):
+            if when == 'after':
+                file.write(b'\x50\x4b\x03\x04 truncated')
+            raise OSError(28, 'No space left on device')
+
+        monkeypatch.setattr(migrate_depth_artifacts.np, 'savez_compressed', failing)
+
+    @pytest.mark.parametrize('when', ['after', 'before'])
+    def test_the_v1_artifact_survives_byte_for_byte(self, tmp_path, monkeypatch, when):
+        storage = str(tmp_path)
+        path = write_v1(storage, 'abcdef')
+        original = read_bytes(path)
+
+        self.fail_during_save(monkeypatch, when)
+        summary = migrate_depth_artifacts.migrate_store(storage)
+
+        assert (summary.scanned, summary.migrated, summary.failed) == (1, 0, 1)
+        assert read_bytes(path) == original, 'a half-written rewrite replaced the artifact'
+        assert not os.path.exists(path + '.part'), 'debris left behind for the next run to trip over'
+
+    def test_the_original_error_is_what_migrate_store_counts(self, tmp_path, monkeypatch):
+        """Failing before the first byte means the cleanup's own os.remove fails too. If that
+        FileNotFoundError escaped it would replace the real cause - here, a full disk - with a message about
+        a temp file, and migrate_store's per-artifact report would send the operator the wrong way."""
+        storage = str(tmp_path)
+        write_v1(storage, 'abcdef')
+        self.fail_during_save(monkeypatch, 'before')
+
+        with pytest.raises(OSError) as excinfo:
+            migrate_depth_artifacts._migrate_artifact(v1_path(storage, 'abcdef'))
+
+        assert excinfo.value.errno == 28
+
+    def test_a_part_path_that_cannot_be_removed_does_not_mask_the_real_error(self, tmp_path):
+        """The cleanup's own os.remove can fail too - here because undeletable debris is sitting at the .part
+        path, which is also why the write failed. Letting that second error replace the first would report a
+        temp-file problem instead of whatever actually stopped the rewrite."""
+        storage = str(tmp_path)
+        path = write_v1(storage, 'abcdef')
+        original = read_bytes(path)
+        # A directory cannot be opened for writing, and cannot be os.remove'd either.
+        os.mkdir(path + '.part')
+
+        with pytest.raises(OSError):
+            migrate_depth_artifacts._migrate_artifact(path)
+
+        assert read_bytes(path) == original
+        assert os.path.isdir(path + '.part'), 'the cleanup should not have half-removed the debris'


### PR DESCRIPTION
Closes #57. Stacked on #92 — GitHub will retarget this to `master` when that merges.

## First, #57's premise is stale

The issue was filed at 58 tests, and its central finding — "`downloaders/gsv.py` is the only production module any test imports" — has not been true for a while. Three of its four steps were delivered by the bug-fix PRs that followed it. Correcting the table before anyone acts on it:

| Module | #57 said | Actually, at this PR's base |
|---|---|---|
| `CropRunner.py` | **nothing** | 97.0% |
| `DownloadRunner.py` | subprocess only, 6 tests | 97.6%, driven in-process |
| `config.py` | **nothing** | 100% |
| `downloaders/mapillary.py` | **nothing** | 83.1% |
| `downloaders/common.py` | **nothing** | 90.5% |
| `downloaders/gsv.py` | depth half only | 97.6%, both halves |

Steps 1, 2 and 4 are done: `main()` is extracted in both runners, every bug the issue lists is closed, and `CropRunner` is no longer dormant-and-untested. **Step 3 — measure it — had never been done.** No `pytest.ini`, `pyproject.toml`, `setup.cfg` or `.coveragerc` existed anywhere in the repo.

## Getting a number that isn't a lie

This was the hard part, and it is why the first commit is mostly config with a long comment.

The runner tests drive the scripts as **real subprocesses**, so `main()`, the argparse `type=` validators, the budget carve-out prints and both `__main__` guards only ever execute in a child. Three separate things have to line up before any of that is measured, and **each one fails silently** — you get a plausible lower number, not an error:

- coverage's `.pth` hook measures a child only when `COVERAGE_PROCESS_START` names a config. `pytest-cov` does not set it.
- the **data file** is resolved against the child's CWD, and every helper spawns with `cwd=tmp_path` — so children measured correctly and then wrote their data into a directory pytest deletes.
- **`source` is resolved against the child's CWD too**, so a bare `.` means "measure the temp directory". It is written `${SIDEWALK_COVERAGE_ROOT-.}` for exactly this reason.

With all three wrong, `DownloadRunner.py` reads **87.9%** and seven well-tested ranges look dead. The next person to read that goes off writing tests that already exist. With them right it reads **97.6%**. Both figures re-measured on the current tree by disabling `pytest_configure` and running the suite again.

`tests/conftest.py`'s `pytest_configure` sets all three, and only when the parent is itself being measured, so an ordinary `pytest tests` run doesn't litter `.coverage.*` files.

`branch = True` matters just as much: the gap that motivated this whole gate was an `if` that only ever went one way.

### The pinned set already earned its keep

`tests/test_coverage_config.py` pins the resolved measured set **exactly**, so a new module has to be a deliberate measure-or-omit decision rather than a default of invisibility. While this branch was in review, #89 added `assets/make_banner.py` — and the pin failed on the rebase, exactly as designed. It is omitted (building the README hero figure is tooling about the repo, not part of the scraper, and `test_make_banner.py` covers it), and that decision is now written down in `.coveragerc` next to `reports/*` and `flag_panos/*`.

## What the measurement found

The headline gap was `downloaders/__init__.py` at **28.6%** — `download_pano`'s entire body. Its docstring states the #41 ledger contract both downloaders are held to, and says *"Both downloaders are held to this by tests/test_image_downloaders.py"* — but the dispatcher itself had never been called with a real source string.

The arm that matters most: **an unrecognised source RAISES rather than returning `DownloadResult.failure`.** That distinction is the difference between one log line per run and permanently blacklisting a city's corpus over a few hours of deploy skew.

| Module | Base of this PR | After |
|---|---|---|
| `CropRunner.py` | 97.0% | **100.0%** |
| `DownloadRunner.py` | 97.6% | **99.7%** |
| `config.py` | 100.0% | 100.0% |
| `downloaders/__init__.py` | 28.6% | **100.0%** |
| `downloaders/common.py` | 90.5% | **100.0%** |
| `downloaders/gsv.py` | 97.6% | **99.0%** |
| `downloaders/mapillary.py` | 83.1% | **98.6%** |
| `log_analyzer/analyze.py` | 99.1% | 99.1% |
| `migrate_depth_artifacts.py` | 91.7% | **100.0%** |
| **TOTAL** | **96.2%** | **99.4%** |

The floor is set at 95 by the first commit and ratcheted to **98** by the last — a ratchet against collapse, not a target. Never lowered; raised only by the PR that earns it.

## Discrimination evidence

Every claim in the backfill commit was re-broken and re-tested. **15 mutations, 15 killed, zero survivors** — re-run in full after each rebase, so this table is against the tree as it stands now, not the one the tests were written on:

| # | Mutation | Killed by |
|---|---|---|
| 1 | Unknown source returns `failure` instead of raising | `test_an_unrecognised_source_raises_rather_than_ledgering_the_pano` |
| 2 | `pano_info['source']` instead of `.get('source', 'gsv')` | `test_a_pano_with_no_source_field_defaults_to_gsv` |
| 3 | Route `gsv` to the mapillary downloader | `test_a_gsv_pano_reaches_gsv_with_its_arguments_intact` |
| 4 | Transpose two slots of the returned 5-tuple | `test_each_verdict_is_counted_in_its_own_slot` |
| 5 | Ledger a raised error (`downloaded = 0` not `None`) | `test_transient_failure_is_not_ledgered_and_retries_next_run` |
| 6 | Drop `raise_for_status()` on the pano fetch | `test_a_server_error_raises_rather_than_returning_an_empty_corpus` |
| 7 | Skip `_normalize_pano_records` on the server path | `test_numeric_and_duplicate_ids_are_normalised_on_the_server_path_too` |
| 8 | Hardcode the connector cap instead of `thread_count` | `test_the_connector_carries_the_configured_concurrency_cap` |
| 9 | Reverse the tile gather's result order | `test_results_come_back_in_the_order_they_were_requested` |
| 10 | Remove `_stitch_cell_size`'s empty-list guard | `test_no_tiles_yields_the_nominal_tile_size` |
| 11 | Let `atomic_output_path`'s own cleanup error escape | `test_a_part_file_that_was_never_created_does_not_mask_the_real_error` |
| 12 | Narrow the log-open `except` so the stderr fallback can't fire | `test_the_run_falls_back_to_a_stream_handler` |
| 13 | `close_after = True` — close an image handed in | `test_an_image_handed_in_is_left_open_for_its_other_labels` |
| 14 | Move the on-disk skip after the token check | `test_an_existing_jpg_is_skipped_before_the_token_or_the_network` |
| 15 | Mount the mapillary retry adapter on one scheme only | `test_both_schemes_carry_the_retry_policy` |

### Two of my own tests were vacuous, and the drill is what said so

Both fixed in the third commit, before the ratchet:

- The **counter-slot test** used one pano per verdict, so all four counters read `1` and any transposition in the returned tuple was invisible. Distinct multiplicities now make the tuple unique to the correct wiring. (Mutation 4 above; it survived until the test was fixed.)
- The **leak check** asserted `image.fp is None`, which PIL sets as soon as the pixels are loaded — `crop()` forces that — so it was true whether or not `close()` was ever called. It now records `close()` through a proxy. (Mutation 13.)

That is the same failure shape the repo has hit before: a test that passes for a reason unrelated to what it claims to check.

## Deliberately still uncovered (~0.6%)

No `# pragma: no cover` on any of it, because a pragma is a claim. The list lives next to `fail_under` in `.coveragerc` rather than in a PR comment:

- `gsv.py`'s `except ImportError` fallback for `depth_min_request_interval` — real deployment behaviour (the scraper box carries local edits to `config.py`), but `gsv` uses relative imports, so it can't be re-executed against a stub config the way `analyze.py` can.
- `gsv.py`'s `_get_response(stream=False)` arm, a dead affordance whose fix is deletion rather than a test.
- `gsv.py`'s photometa early return for a message carrying no depth planes.
- `DownloadRunner`'s `fallback_success` counter arm: no code path in the suite produces that verdict.
- Three partial branches needing an input no caller produces — mapillary's falsy-chunk skip, and `analyze.py`'s two loop guards.

## Rebased twice while in review

#89, #90 and #91 all merged after this branch was pushed, and it has been rebased onto each:

- **#90** deleted `gsv.py`'s legacy `.xml` branch — which was the single largest uncovered range in the tree, and the reason `gsv.py` now reads 99.0% rather than 93.4%. (The dropped PR D from my original plan was going to delete it; #90 got there first, with a store measurement I couldn't run.)
- **#91** moved `pandas` out of `requirements.txt`, which is why the floor bump in #92 lands in `requirements-dev.txt`.
- **#89** replaced the README with a `docs/` set, so the coverage documentation this PR adds went to `docs/testing.md`, and retired the Docker entrypoint — which is why the skip count is 11 rather than 24.

## Test plan

- `1799 passed, 11 skipped`, **99.41%** total, `fail_under = 98` satisfied, branch coverage on.
- CI measured the same 99.41% on Ubuntu (`1802 passed, 8 skipped`). Of the 11 local skips, 3 are `posix_only` file-mode assertions that do run on CI — they assert modes on files other tests already wrote, so they reach no new lines, which is why the two figures agree rather than CI coming out higher. The other 8 are the `SIDEWALK_LIVE_TILE_TESTS` opt-ins, which skip everywhere including CI.
- Network-free throughout.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])
