### PR TITLE
Give the zoom probe the timeout the depth phase already had (#65 item 5)

### DIFF
--- a/downloaders/gsv.py
+++ b/downloaders/gsv.py
@@ -57,10 +57,32 @@ def _random_header():
     return random.choice(headers_list)
 
 
+class _TimeoutHTTPAdapter(HTTPAdapter):
+    """HTTPAdapter that applies a default timeout to every request.
+
+    `requests` sets no default timeout of its own, so without this one hung connection stalls a nightly cron
+    run indefinitely - not for a long time, forever. Both sessions below need it, for the same reason from
+    opposite ends: streetlevel's photometa requests carry no timeout and expose no per-request hook to add
+    one, and the image path's zoom probes never set one either (#65 item 5).
+    """
+
+    def __init__(self, *args, timeout=30, **kwargs):
+        self._timeout = timeout
+        super().__init__(*args, **kwargs)
+
+    def send(self, request, **kwargs):
+        # Session.send always passes timeout as a kwarg (None when the caller set nothing), so a plain
+        # setdefault would never fire.
+        if kwargs.get('timeout') is None:
+            kwargs['timeout'] = self._timeout
+        return super().send(request, **kwargs)
+
+
 def _request_session():
+    """The session the zoom probes ride on: retries, plus the default timeout _TimeoutHTTPAdapter adds."""
     session = requests.Session()
     retry = Retry(total=5, connect=5, status_forcelist=[429, 500, 502, 503, 504], backoff_factor=1)
-    adapter = HTTPAdapter(max_retries=retry)
+    adapter = _TimeoutHTTPAdapter(max_retries=retry, timeout=30)
     session.mount('http://', adapter)
     session.mount('https://', adapter)
     return session
@@ -483,30 +505,11 @@ def _raise_if_blocked(response, *args, **kwargs):
                 raise DepthBlockedError("redirected to %s" % (url))
 
 
-class _TimeoutHTTPAdapter(HTTPAdapter):
-    """HTTPAdapter that applies a default timeout to every request.
-
-    streetlevel's internal requests carry no timeout, so without this a single hung connection would stall a
-    nightly cron run indefinitely.
-    """
-
-    def __init__(self, *args, timeout=30, **kwargs):
-        self._timeout = timeout
-        super().__init__(*args, **kwargs)
-
-    def send(self, request, **kwargs):
-        # Session.send always passes timeout as a kwarg (None when the caller set nothing), so a plain
-        # setdefault would never fire.
-        if kwargs.get('timeout') is None:
-            kwargs['timeout'] = self._timeout
-        return super().send(request, **kwargs)
-
-
 def _depth_session():
     """Build the requests.Session handed to streetlevel for photometa requests.
 
-    Same retry policy as _request_session(), plus a default timeout (streetlevel never sets one), backoff jitter,
-    and the block-detection hook.
+    Same retry policy and default timeout as _request_session(), plus backoff jitter and the
+    block-detection hook.
 
     Deliberately does NOT borrow config.headers_list the way the tile downloader does. streetlevel sends its own
     Accept/Host/Referer/User-Agent on every photometa request, and in requests a request-level header beats a

--- a/tests/test_gsv_stitcher.py
+++ b/tests/test_gsv_stitcher.py
@@ -12,6 +12,7 @@ import aiohttp
 import numpy as np
 import pytest
 from PIL import Image
+from requests.adapters import HTTPAdapter
 
 from downloaders import gsv
 from downloaders.common import DownloadResult
@@ -784,3 +785,45 @@ class TestAnEmptyFanOutStillHasACellSize:
         """`max()` over an empty sequence raises, which would turn a zero-tile fan-out from "mostly black,
         refused by the black guard" into an unexplained ValueError with no pano id attached."""
         assert gsv._stitch_cell_size([]) == (gsv.TILE_SIZE, gsv.TILE_SIZE)
+
+
+class TestRequestSessionCannotHangForever:
+    """The image path's session, which the zoom probes ride on (#65 item 5).
+
+    `requests` applies NO default timeout, so a hung connection here stalls a nightly cron run
+    indefinitely - not for a long time, forever. The depth phase fixed exactly this hazard for itself with
+    _TimeoutHTTPAdapter; the image path never got it, even though the zoom probe runs once per pano
+    (~183k times a night on Seattle alone).
+
+    The tile fan-out is not exposed the same way - aiohttp's ClientSession carries its own default total
+    timeout - so the probe is the whole of it.
+    """
+
+    def test_mounts_the_timeout_adapter_on_both_schemes(self):
+        session = gsv._request_session()
+        for prefix in ('http://', 'https://'):
+            adapter = session.get_adapter(prefix + 'example.com')
+            assert isinstance(adapter, gsv._TimeoutHTTPAdapter)
+
+    def test_keeps_the_retry_policy_it_already_had(self):
+        """The timeout is additive: #65 item 5 is about a missing timeout, not about retries."""
+        adapter = gsv._request_session().get_adapter('https://example.com')
+        assert adapter.max_retries.total == 5
+        assert adapter.max_retries.connect == 5
+        assert 429 in adapter.max_retries.status_forcelist
+
+    def test_the_mounted_adapter_actually_injects_a_timeout(self, monkeypatch):
+        """Behavioural, not just isinstance: a mounted adapter configured `timeout=None` would satisfy the
+        type check and still hang. Session.send always passes timeout explicitly, as None when the caller
+        set nothing, which is exactly what _get_response does."""
+        captured = {}
+
+        def fake_send(self, request, **kwargs):
+            captured.update(kwargs)
+            return 'response'
+
+        monkeypatch.setattr(HTTPAdapter, 'send', fake_send)
+        adapter = gsv._request_session().get_adapter('https://example.com')
+        adapter.send('request', timeout=None)
+        assert captured['timeout'] is not None
+        assert captured['timeout'] > 0


### PR DESCRIPTION
Closes the last live item in #65.

`requests` sets no default timeout. `_request_session()` mounted a plain `HTTPAdapter`, and
`_get_response` passes no `timeout=`, so a hung connection on a **zoom probe stalled a nightly cron run
indefinitely** — not for a long time, forever. The depth phase fixed exactly this hazard for itself with
`_TimeoutHTTPAdapter` (#62); the image path never got it.

That matters more than it looks: the probe runs **once per pano** — ~183k times a night on Seattle alone
— and it is the last unbounded wait left in either phase. The tile fan-out is not exposed the same way,
because aiohttp's `ClientSession` carries its own default total timeout, so the probe is the whole of it.

## What changed

- **`_TimeoutHTTPAdapter` moves above `_request_session`** so it visibly serves both sessions, rather than
  being a forward reference from line 63 to a class defined 500 lines further down.
- **`_request_session()` mounts it** with the same `timeout=30` the depth session uses.
- **Two docstrings that were quietly wrong.** The adapter's said the timeout existed because streetlevel
  sets none — now half the reason, so it names both ends. `_depth_session`'s claimed the timeout as *its*
  differentiator from `_request_session`; the difference is now backoff jitter, the block hook and proxies.

No behaviour changes for the depth phase, and the retry policy is untouched — this is additive.

## Tests

Written first, and RED in the right shape: the two new assertions failed while
`test_keeps_the_retry_policy_it_already_had` passed, so the red was the missing timeout rather than a
broken fixture.

The isinstance check alone would not be enough — **a mounted adapter configured `timeout=None` satisfies
it and still hangs** — so the third test asserts a timeout actually reaches `send`. That is the mutant the
behavioural test exists to kill, and it is one of five:

| mutant | killed by |
|---|---|
| revert to plain `HTTPAdapter` (the original defect) | isinstance + behavioural |
| mounted adapter with `timeout=None` | behavioural only |
| `timeout=0` (falsy, no real bound) | behavioural only |
| `send` stops injecting | behavioural |
| adapter mounted on `https://` only | isinstance on both schemes |

**5/5 killed.** Full suite on this branch: 1,802 passed, 11 skipped, coverage 99.41% against the 98% gate.

## Why now

Found while auditing #65 ahead of the EC2 deploy. **It is not a regression** — the build currently running
in production has the same gap — but it is a cron hang risk in the hottest path, and it is cheap to land
before the deploy rather than after.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])
