### PR TITLE
Record that production actually moved off the Docker image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Python tooling that works with data from [Project Sidewalk](https://github.com/P
 
 ## Common Commands
 
-Everything runs from a virtualenv — **there is no Docker in this repo**. The image and its sshfs entrypoint were retired in Aug 2026 (`docs/history.md`); production is a crontab line per city calling `.venv/bin/python` directly, with the pano store mounted on the host.
+Everything runs from a virtualenv — **there is no Docker in this repo**. The image and its sshfs entrypoint were retired from the repo in Aug 2026 and from the production box on 2026-09-01 (`docs/history.md`); production is a crontab line per city calling `.venv/bin/python` directly, with the pano store mounted on the host.
 
 ```bash
 python3 -m venv .venv && source .venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ for the nightly cron form.
 > **Requirements:** Python 3.10+ and ~2 GB RAM (a 16384×8192 panorama is 384 MB decoded). Linux is the
 > supported production platform; macOS and Windows are fine for development, though the depth phase's
 > `pyfrpc` dependency ships wheels for Linux only. **No Docker** — the image and its sshfs entrypoint were
-> [retired in Aug 2026](docs/history.md#the-docker-image-aug-2026).
+> [retired from the repo in Aug 2026](docs/history.md#the-docker-image-aug-2026), and from the production box
+> in Sep 2026.
 
 ## Documentation
 

--- a/docs/downloader.md
+++ b/docs/downloader.md
@@ -122,11 +122,14 @@ user@store.example.edu:/panos  /mnt/panostore  fuse.sshfs
     _netdev,IdentityFile=/root/.ssh/id_rsa,reconnect,ServerAliveInterval=15,allow_other  0 0
 ```
 
-A systemd `.mount` unit is the version running in production since 2026-09-01. The unit's filename must match
-the mount point (`/mnt/panostore` becomes `mnt-panostore.mount`) or systemd refuses it, and `allow_other` needs
-`user_allow_other` uncommented in `/etc/fuse.conf`. systemd mounts as root, so the key and the host's
-`known_hosts` entry have to be readable by root, not just by the cron user; `uid=`/`gid=` then hand the files to
-whoever cron runs as:
+A systemd `.mount` unit is the version running in production since 2026-09-01. Three things about it are not
+obvious. The unit's **filename must match the mount point** — `/mnt/panostore` becomes `mnt-panostore.mount` —
+or systemd refuses to load it. systemd mounts as **root**, so the identity file and the host key must be where
+*root's* ssh looks, under `/root/.ssh/`: an entry in the cron user's `known_hosts` is never consulted, which is
+a location problem rather than a permission one (root can read the file either way), and ssh rejects a private
+key whose mode is more permissive than `0600`. And **`uid=`/`gid=` hand the mounted files to whoever cron runs
+as** — substitute that account's real ids rather than assuming 1000, because with `default_permissions` a wrong
+id gives a mount that looks healthy while every write returns `EACCES`.
 
 ```ini
 [Unit]
@@ -138,15 +141,33 @@ Wants=network-online.target
 What=user@store.example.edu:/panos
 Where=/mnt/panostore
 Type=fuse.sshfs
-Options=_netdev,IdentityFile=/root/.ssh/id_rsa,port=22,reconnect,ServerAliveInterval=15,ServerAliveCountMax=3,allow_other,default_permissions,uid=1000,gid=1000
+Options=IdentityFile=/root/.ssh/id_rsa,port=2222,reconnect,ServerAliveInterval=15,ServerAliveCountMax=3,allow_other,default_permissions,uid=1000,gid=1000
 TimeoutSec=90
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=remote-fs.target
 ```
 
-A store that is unmounted or full shows up as counted, retried per-pano failures — never as a crash and never
-as a ledgered permanent verdict — so the next run picks the work back up once the mount is fixed. The depth
+Two things deliberately absent. `allow_other` needs `user_allow_other` in `/etc/fuse.conf` only when a
+**non-root** user mounts; `fusermount` skips that check for root, so a systemd unit does not need it. And
+`_netdev` is an fstab-generator directive — a native unit derives no ordering from `Options=`, so the explicit
+`After=`/`Wants=` is what actually does the work.
+
+**Harden the mount point itself.** This is the one failure the unit makes *more* likely rather than less:
+
+```bash
+chown root:root /mnt/panostore && chmod 555 /mnt/panostore
+```
+
+`reconnect` only covers the ssh session dropping *within* sshfs's lifetime. If sshfs exits, the unit goes
+inactive and the mount point reverts to an ordinary local directory — and if that directory is writable, the
+next cron run downloads into the root filesystem instead, reports success, and fills the disk. An unwritable
+mount point turns that silent corruption into the ordinary per-pano write failures described next. (An
+`.automount` unit is the other answer; it remounts on access rather than failing.)
+
+A store that is full — or unmounted, *provided the mount point is unwritable as above* — shows up as counted,
+retried per-pano failures, never as a crash and never as a ledgered permanent verdict, so the next run picks the
+work back up once the mount is fixed. The depth
 phase's circuit breaker prints the failure breakdown by cause, which is how you tell a full disk from Google
 pushing back ([Depth maps](depth.md#being-a-good-citizen-of-googles-servers)).
 
@@ -164,13 +185,21 @@ the form above, and drop the `id_rsa` that used to be baked into the image. Flag
 Nothing about the store's on-disk layout changes, so a store the image has been writing to since 2022 is
 picked up as-is.
 
-**Done on the production box 2026-09-01**, and two things about it are worth passing on. The old host could not
-be migrated in place — its Python was 3.5 and the image's was 3.8, so both were below this page's 3.10 baseline
-and the move had to be to a new machine rather than a new virtualenv. And the per-flag promise above held, but
-the *sizing* did not transfer: the retired crontab gave every city `--max-runtime 1320` on a 15-minute stagger,
-which is harmless only while runs finish in seconds because they have nothing to download. Re-check
-`--max-runtime` against the slot spacing when a run starts doing real work, rather than copying the old numbers
-across.
+**Done on the production box 2026-09-01**, and three things about it are worth passing on.
+
+The old host could not be migrated in place. Its Python was **3.5** (Ubuntu 16.04), and the image it was
+actually running carried **3.8** — that image was built from the `ubuntu:20.04` Dockerfile this repo shipped
+until Aug 2026, not the `ubuntu:22.04` one that was eventually deleted. Both sit below this page's 3.10
+baseline, so the move had to be to a new machine rather than a new virtualenv on the old one.
+
+The per-flag promise above held, but **the sizing did not transfer** — and the retired crontab was not what this
+page recommends. Every city carried `--max-runtime 1320` and no `--min-depth-runtime` at all, against the
+`360 / 60` above. That is harmless only while runs finish in seconds because they have nothing to download.
+
+Sizing is also not a per-city question. With ~50 cities on a 15-minute stagger the schedule spans half a day, so
+no `--max-runtime` large enough to do real work avoids overlap and shrinking the flag alone cannot fix it: the
+levers are the stagger and how many runs may overlap. That matters most for depth, whose throttle is
+per-process — see [Depth maps](depth.md#being-a-good-citizen-of-googles-servers).
 
 ## Imagery sources
 

--- a/docs/downloader.md
+++ b/docs/downloader.md
@@ -122,6 +122,29 @@ user@store.example.edu:/panos  /mnt/panostore  fuse.sshfs
     _netdev,IdentityFile=/root/.ssh/id_rsa,reconnect,ServerAliveInterval=15,allow_other  0 0
 ```
 
+A systemd `.mount` unit is the version running in production since 2026-09-01. The unit's filename must match
+the mount point (`/mnt/panostore` becomes `mnt-panostore.mount`) or systemd refuses it, and `allow_other` needs
+`user_allow_other` uncommented in `/etc/fuse.conf`. systemd mounts as root, so the key and the host's
+`known_hosts` entry have to be readable by root, not just by the cron user; `uid=`/`gid=` then hand the files to
+whoever cron runs as:
+
+```ini
+[Unit]
+Description=Pano store (sshfs)
+After=network-online.target
+Wants=network-online.target
+
+[Mount]
+What=user@store.example.edu:/panos
+Where=/mnt/panostore
+Type=fuse.sshfs
+Options=_netdev,IdentityFile=/root/.ssh/id_rsa,port=22,reconnect,ServerAliveInterval=15,ServerAliveCountMax=3,allow_other,default_permissions,uid=1000,gid=1000
+TimeoutSec=90
+
+[Install]
+WantedBy=multi-user.target
+```
+
 A store that is unmounted or full shows up as counted, retried per-pano failures — never as a crash and never
 as a ledgered permanent verdict — so the next run picks the work back up once the mount is fixed. The depth
 phase's circuit breaker prints the failure breakdown by cause, which is how you tell a full disk from Google
@@ -140,6 +163,14 @@ To migrate: create the venv as above, mount the store on the host, replace each 
 the form above, and drop the `id_rsa` that used to be baked into the image. Flags and semantics are unchanged.
 Nothing about the store's on-disk layout changes, so a store the image has been writing to since 2022 is
 picked up as-is.
+
+**Done on the production box 2026-09-01**, and two things about it are worth passing on. The old host could not
+be migrated in place — its Python was 3.5 and the image's was 3.8, so both were below this page's 3.10 baseline
+and the move had to be to a new machine rather than a new virtualenv. And the per-flag promise above held, but
+the *sizing* did not transfer: the retired crontab gave every city `--max-runtime 1320` on a 15-minute stagger,
+which is harmless only while runs finish in seconds because they have nothing to download. Re-check
+`--max-runtime` against the slot spacing when a run starts doing real work, rather than copying the old numbers
+across.
 
 ## Imagery sources
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -10,8 +10,15 @@ virtualenv, per [Downloader → Install](downloader.md#install).
 
 **The repo and production retired it a month apart.** The files came out in Aug 2026, but the scraper box kept
 running `projectsidewalk/scraper:v6` on one crontab line per city until **2026-09-01**, when it moved to a new
-Ubuntu 22.04 host running the venv. So for that month the docs described a deployment that did not exist — worth
-remembering the next time a "retired" note is written before the box it describes has been touched.
+Ubuntu 22.04 host running the venv.
+
+The specific thing that was wrong is worth naming, because it is the kind of claim that is easy to make and
+hard to check: the retiring commit's own message said "Production has been a crontab line per city calling
+`.venv/bin/python` against a host mount **for a while now**", and used that as part of its justification for
+the delete. Production was in fact still running the image, from a checkout 183 commits behind `master`. The
+delete was still right — the image bought nothing the venv doesn't — but the reason given for it was not true
+yet, and nothing in CI could have caught that. A claim about what a machine is doing needs to come from the
+machine.
 
 The image existed to pin Ubuntu 22.04 / Python 3.10 and to sshfs-mount the pano store from inside the
 container — the reason the documented `docker run` needed `--cap-add SYS_ADMIN --device=/dev/fuse

--- a/docs/history.md
+++ b/docs/history.md
@@ -8,6 +8,11 @@ out whether something was dropped on purpose.
 `Dockerfile` and `DownloadRunnerDockerEntrypoint.sh` are gone; the supported way to run the downloader is a
 virtualenv, per [Downloader → Install](downloader.md#install).
 
+**The repo and production retired it a month apart.** The files came out in Aug 2026, but the scraper box kept
+running `projectsidewalk/scraper:v6` on one crontab line per city until **2026-09-01**, when it moved to a new
+Ubuntu 22.04 host running the venv. So for that month the docs described a deployment that did not exist — worth
+remembering the next time a "retired" note is written before the box it describes has been touched.
+
 The image existed to pin Ubuntu 22.04 / Python 3.10 and to sshfs-mount the pano store from inside the
 container — the reason the documented `docker run` needed `--cap-add SYS_ADMIN --device=/dev/fuse
 --security-opt apparmor:unconfined`. Almost all of the entrypoint's complexity was spent undoing problems the


### PR DESCRIPTION
The repo retired `Dockerfile` and the sshfs entrypoint in Aug 2026 (cc09522), but the production scraper box kept running `projectsidewalk/scraper:v6` on one crontab line per city until **2026-09-01**, when it moved to a new Ubuntu 22.04 host running the venv.

So for about a month `CLAUDE.md` and `docs/history.md` described a deployment that did not exist. Anyone reading them to plan work against production would have been planning against the wrong machine.

### Changes

* **`CLAUDE.md`** — dates the production claim instead of stating it flatly.
* **`README.md`** — distinguishes retired-from-the-repo from retired-from-the-box.
* **`docs/history.md`** — records that the repo and the box retired the image a month apart, and names the specific claim being retracted: cc09522's own commit message justified the delete partly on *"Production has been a crontab line per city calling .venv/bin/python against a host mount for a while now"*, which was not true. The delete was still right; the reason given for it was not yet true, and nothing in CI could have caught that.
* **`docs/downloader.md`** — adds the systemd `.mount` unit now running in production, and corrects the sizing advice.

### On verification — narrower than it first sounds

An earlier version of this description said cutover was "verified end to end" because a run from the new host wrote a `log.csv` row byte-identical in all 18 fields to the old box's. **That claim was too strong.** Durations are rounded to whole minutes, so a run that downloads nothing writes `0` in all four duration fields, and the pano counts match trivially when everything is already ledgered — an identical row is exactly what you get when *both* runs did nothing.

What it actually verifies: the new host reaches `/adminapi/panos`, reads the ledgers, and appends to the store over the mount. The download path was exercised separately and for real — a `richmond-va` run on the new host downloaded 161 panos successfully. The GSV stitch path has not been exercised on the new host yet; it will be the first time a city has new imagery.

### Review fixes applied

Independent review found several errors, all now corrected:

* **`allow_other` does not need `user_allow_other`** when systemd mounts as root — `fusermount` skips that check for uid 0. It was listed as one of "three things that bite" and was the one that doesn't.
* **The `known_hosts` reasoning was wrong.** Root reads any local file; the issue is *location* (root's ssh reads `/root/.ssh/known_hosts`), not permissions. As written it would send a reader to `chmod` instead of copy.
* **`_netdev` is inert** in a native `.mount` unit, and **`WantedBy=` should be `remote-fs.target`**, not `multi-user.target`.
* **`uid=1000` was presented as "whoever cron runs as"** while being a hardcoded literal — now flagged as a substitution, since with `default_permissions` a wrong id gives a mount that looks healthy while every write returns `EACCES`.
* **The Python claim contradicted two other pages.** The Dockerfile at deletion was `FROM ubuntu:22.04` (3.10). The 3.8 measurement is real but describes the image the box was *running*, built from the `ubuntu:20.04` Dockerfile shipped until Aug 2026. Now stated with that distinction.
* **The sizing advice was incomplete.** With ~50 cities on a 15-minute stagger the schedule spans half a day, so no `--max-runtime` large enough to do real work avoids overlap — the levers are the stagger and the overlap count, not the flag. The retired crontab also diverged from this page's own `360 / 60` recommendation and set no `--min-depth-runtime` at all.

### One real defect this surfaced, now fixed on the box

The review pointed out that `reconnect` only covers the ssh session dropping *within* sshfs's lifetime. If sshfs exits, the mount point reverts to an ordinary local directory — and if it is writable, the next cron run downloads into the root filesystem, reports success, and fills the disk. The page's claim that an unmounted store shows up as retried per-pano failures was only true for a *full* store.

The mount point on the production box is now `root:root 555`, which makes that claim true, and the fix is documented alongside the unit.

Docs only; no code changes. Full suite: 1804 passed, 11 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])