### PR TITLE
Pin the status a real token expiry produced: 400

### DIFF
--- a/tests/test_image_downloaders.py
+++ b/tests/test_image_downloaders.py
@@ -195,12 +195,20 @@ class TestMapillaryTransientConditions:
     """These are properties of the RUN. Returning failure would ledger them permanently - an expired token
     for one night would blacklist every Mapillary pano in the city - so they must raise instead (#41)."""
 
-    # 400 is not hypothetical. richmond-va's token stopped working and graph.mapillary.com answered every
-    # request with one; the pre-#41 code ledgered each as permanent, writing off 162 panos as "Mapillary has
-    # no image" and never re-attempting them. Recovering them meant hand-editing pano_id_log.csv on the store
-    # (2026-09-01). The status the incident actually produced was the one status this list omitted, so it is
-    # first here.
-    @pytest.mark.parametrize('status', [400, 401, 403, 500])
+    # Only 404 is permanent; every other non-200 must raise. Parametrised over a SPREAD rather than the
+    # statuses we happen to have seen, because the last gap here was exactly that kind of omission. The list
+    # was [401, 403, 500] on the reasoning that those are what a bad token produces; when richmond-va's token
+    # stopped working, graph.mapillary.com answered 400 - the one status not covered. The code deployed then
+    # predated this contract and ledgered any non-200 as permanent, so it wrote off 162 panos as "Mapillary
+    # has no image" (161 of them wrongly - the 162nd was an id that had since left the corpus). The city sat
+    # at 21 of 182 until pano_id_log.csv was hand-edited on the store (2026-09-01), because replacing the
+    # token recovered nothing on its own. Pinning the rule rather than the observed instances is what stops
+    # the next unanticipated status - 402, 410, 451 - from being another gap.
+    #
+    # 500 is a contract case, not a wire case: _session()'s status_forcelist retries 429/500/502/503/504, so
+    # in production those surface as RetryError rather than HTTPError. FakeSession bypasses the adapter.
+    # 400/401/403 are the ones that reach raise_for_status() for real.
+    @pytest.mark.parametrize('status', [400, 401, 402, 403, 410, 422, 451, 500])
     def test_metadata_http_errors_raise(self, monkeypatch, tmp_path, mapillary_token, status):
         monkeypatch.setattr(downloaders.mapillary, '_session',
                             lambda: FakeSession(FakeResponse(status_code=status)))

--- a/tests/test_image_downloaders.py
+++ b/tests/test_image_downloaders.py
@@ -195,7 +195,12 @@ class TestMapillaryTransientConditions:
     """These are properties of the RUN. Returning failure would ledger them permanently - an expired token
     for one night would blacklist every Mapillary pano in the city - so they must raise instead (#41)."""
 
-    @pytest.mark.parametrize('status', [401, 403, 500])
+    # 400 is not hypothetical. richmond-va's token stopped working and graph.mapillary.com answered every
+    # request with one; the pre-#41 code ledgered each as permanent, writing off 162 panos as "Mapillary has
+    # no image" and never re-attempting them. Recovering them meant hand-editing pano_id_log.csv on the store
+    # (2026-09-01). The status the incident actually produced was the one status this list omitted, so it is
+    # first here.
+    @pytest.mark.parametrize('status', [400, 401, 403, 500])
     def test_metadata_http_errors_raise(self, monkeypatch, tmp_path, mapillary_token, status):
         monkeypatch.setattr(downloaders.mapillary, '_session',
                             lambda: FakeSession(FakeResponse(status_code=status)))


### PR DESCRIPTION
`TestMapillaryTransientConditions` parametrised the metadata-error case over **401, 403 and 500** — the statuses a bad token was *assumed* to produce. The one production actually produced was **400**, the single status the list omitted.

### What happened

`richmond-va`'s Mapillary token stopped working and `graph.mapillary.com` answered every request with `400`. The code deployed at the time predated the #41 ledger contract and returned `DownloadResult.failure` for any non-200, so it wrote **162 `downloaded=0` rows** — permanent *"Mapillary has no image"* verdicts that are never re-attempted.

**161 of those were false.** The 162nd is an id that has since left `/adminapi/panos`, which is why the recovery run reported `0 failed` rather than `1`. The city sat at **21 of 182 panos**; replacing the token recovered nothing on its own, and `pano_id_log.csv` had to be hand-edited on the store. The same run then returned `161 success, 0 failed`, completing the city at 182.

### What this change does

**Pins the rule, not the observed statuses.** The first version of this PR added `400` to the list — which answers an incomplete enumeration by extending it, leaving 402, 410, 422 and 451 exactly as uncovered as 400 had been. The rule is already written in the code (*only 404 is permanent, everything else raises*), so the parametrize now spans a spread and pins that instead, at identical cost.

### What this change is not

**Not a fix.** Current `master` already handles this correctly — only `404` returns a permanent verdict. That landed in 1c5d618 on 2026-08-07, but only *reached production* on 2026-09-01, when the scraper box left `projectsidewalk/scraper:v6` for the venv. The gap between those two dates is the whole story.

**Not closing a mutation-detectable hole.** Reintroducing the pre-#41 bug (`status_code != 200` → permanent) is caught by the pre-existing 401/403/500 cases just as well — verified by applying that mutation and watching every case fail.

### A caveat worth knowing

`_session()`'s `status_forcelist` retries `429/500/502/503/504`, so a real **500 never reaches `raise_for_status()`** — it surfaces as `RetryError`, not the `HTTPError` this test asserts. `FakeSession` bypasses the adapter, so the 5xx case models the contract rather than the wire. **400/401/403 are the cases faithful to production.** Pre-existing, now documented next to the list it explains.

Full suite: 1807 passed, 11 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])