### PR TITLE
Send the Mapillary token as a header, so it stops landing in scrape.log

### DIFF
--- a/docs/downloader.md
+++ b/docs/downloader.md
@@ -226,8 +226,32 @@ export MAPILLARY_ACCESS_TOKEN='MLY|...'
 python3 DownloadRunner.py <sidewalk-fqdn> <storage-dir>
 ```
 
-Without the token, Mapillary panos are filtered out of the run rather than failed. Under cron, set it in the
-crontab or an `EnvironmentFile` — not in a shell profile cron never reads. The first Mapillary city is
+The downloader sends it as an `Authorization: OAuth` header, never as an `access_token` query parameter, so
+it cannot reach a URL — and `requests` puts the full URL into an `HTTPError`'s message, which
+`DownloadRunner` logs verbatim for a failed pano. That is not a hypothetical: production's `scrape.log`
+held a live token in cleartext, on the shared store, after a night of Mapillary 400s.
+
+Without the token, Mapillary panos are filtered out of the run rather than failed — **silently enough to
+miss**, so a city that should have Mapillary imagery and downloads none is the symptom of a token that never
+arrived.
+
+**Under cron, keep it out of the crontab body.** `crontab -l` output lands in backups, screenshots and
+pastes, and the file itself outlives the person who wrote it. Put it in a mode-`600` file and let bash source
+it for every line — cron sets `BASH_ENV` in the child's environment, and non-interactive bash reads it:
+
+```cron
+SHELL=/bin/bash
+BASH_ENV=/home/ubuntu/.scraper.env
+```
+
+```bash
+# /home/ubuntu/.scraper.env — mode 600, owned by the cron user
+export MAPILLARY_ACCESS_TOKEN='MLY|...'
+```
+
+`SHELL=/bin/bash` is load-bearing: under `/bin/sh` (dash) `BASH_ENV` is ignored and the token is simply
+unset, which fails as a *quiet* filtering-out rather than an error. Verify with a throwaway crontab line
+that echoes `${#MAPILLARY_ACCESS_TOKEN}` to a file — the length, never the value. The first Mapillary city is
 measured in [reports/2026-08-11-mapillary-census.md](../reports/2026-08-11-mapillary-census.md).
 
 ## `config.py`

--- a/downloaders/mapillary.py
+++ b/downloaders/mapillary.py
@@ -59,7 +59,14 @@ def download_single_pano(storage_path, pano_info):
     with _session() as session:
         meta_resp = session.get(
             f'{GRAPH_API_BASE}/{pano_id}',
-            params={'fields': 'thumb_original_url', 'access_token': token},
+            params={'fields': 'thumb_original_url'},
+            # The token travels in the header, never the query string. requests puts the full URL in an
+            # HTTPError's message and DownloadRunner logs str(e) for a failed pano, so a token in params
+            # is a token in cleartext in scrape.log - which lives on the SHARED pano store, readable by
+            # every lab user. Not hypothetical: richmond-va's scrape.log held a live token after the
+            # 2026-09-01 400s. Graph API v4 accepts either form; only this one keeps the secret out of
+            # URLs, logs, and any intermediary's access log.
+            headers={'Authorization': 'OAuth %s' % token},
             timeout=30,
         )
         if meta_resp.status_code == 404:

--- a/tests/test_image_downloaders.py
+++ b/tests/test_image_downloaders.py
@@ -151,11 +151,16 @@ class FakeResponse:
 
 
 class FakeSession:
-    """Returns queued responses in order; records the URLs asked for."""
+    """Returns queued responses in order; records the URLs asked for, and the whole call.
+
+    `calls` carries the kwargs as well, because WHERE a secret rides - params or headers - is the thing
+    TestTheTokenStaysOutOfURLs has to see, and the url argument alone cannot show it.
+    """
 
     def __init__(self, *responses):
         self.responses = list(responses)
         self.urls = []
+        self.calls = []
 
     def __enter__(self):
         return self
@@ -165,6 +170,7 @@ class FakeSession:
 
     def get(self, url, **kwargs):
         self.urls.append(url)
+        self.calls.append((url, kwargs))
         return self.responses.pop(0)
 
 
@@ -261,6 +267,65 @@ class TestMapillaryTransientConditions:
         assert downloaders.mapillary.download_single_pano(str(tmp_path), MAPILLARY_PANO) \
             == DownloadResult.success
         assert os.listdir(tmp_path / '12') == ['%s.jpg' % MAPILLARY_PANO['pano_id']]
+
+
+class TestTheTokenStaysOutOfURLs:
+    """A token in the query string is a token in the logs, and these logs are not private.
+
+    `scrape.log` is written to the SHARED pano store, and DownloadRunner logs `str(e)` for every failed
+    pano. requests puts the full URL into an HTTPError's message, so `params={'access_token': ...}` writes
+    the live secret into that file in cleartext. Not hypothetical: richmond-va's `scrape.log` carried a
+    working token after the 2026-09-01 run whose own token had expired. Header auth is the form Graph API
+    v4 documents, and was confirmed against the live API (HTTP 200, thumb_original_url returned) before
+    this change landed.
+    """
+
+    @staticmethod
+    def _url_on_the_wire(call):
+        """Build the URL through requests' OWN machinery, so this test cannot pass by construction.
+
+        Asserting on the bare `url` argument would be vacuous - it never holds the token either way,
+        since params are merged in at prepare() time. Preparing the request is precisely what makes
+        putting access_token back into params fail here.
+        """
+        url, kwargs = call
+        return requests.Request('GET', url, params=kwargs.get('params')).prepare().url
+
+    def _healthy_session(self, monkeypatch):
+        session = FakeSession(FakeResponse(payload={'thumb_original_url': 'https://cdn/x.jpg'}),
+                              FakeResponse(chunks=[jpeg_bytes(120)]))
+        monkeypatch.setattr(downloaders.mapillary, '_session', lambda: session)
+        return session
+
+    def test_the_metadata_url_never_carries_the_token(self, monkeypatch, tmp_path, mapillary_token):
+        session = self._healthy_session(monkeypatch)
+
+        downloaders.mapillary.download_single_pano(str(tmp_path), MAPILLARY_PANO)
+
+        wire_url = self._url_on_the_wire(session.calls[0])
+        assert 'test-token' not in wire_url
+        # The request still has to ask for the field it needs, or "no token in the URL" is trivially
+        # satisfiable by sending no params at all.
+        assert 'fields=thumb_original_url' in wire_url
+
+    def test_the_token_is_still_sent_as_an_oauth_header(self, monkeypatch, tmp_path, mapillary_token):
+        """The other half: dropping the token entirely would also pass the test above, and would take
+        every Mapillary pano in the city down with a 401 the next night."""
+        session = self._healthy_session(monkeypatch)
+
+        downloaders.mapillary.download_single_pano(str(tmp_path), MAPILLARY_PANO)
+
+        assert session.calls[0][1]['headers'] == {'Authorization': 'OAuth test-token'}
+
+    def test_the_signed_image_url_is_fetched_with_no_credentials_of_ours(self, monkeypatch, tmp_path,
+                                                                        mapillary_token):
+        """The CDN URL is already signed and short-lived; sending our token to it would widen the blast
+        radius of a leak from one metadata URL to every image request."""
+        session = self._healthy_session(monkeypatch)
+
+        downloaders.mapillary.download_single_pano(str(tmp_path), MAPILLARY_PANO)
+
+        assert 'test-token' not in str(session.calls[1])
 
 
 class TestGsvAtomicSave:


### PR DESCRIPTION
`downloaders/mapillary.py` passed the token as `params={'access_token': token}`. `requests` writes the full URL into an `HTTPError`'s message, and `DownloadRunner` logs `str(e)` for every failed pano — so on any night Mapillary answers non-200, the live token is written **in cleartext into `scrape.log`, which lives on the shared pano store**.

### Measured, not hypothetical

`richmond-va`'s `scrape.log` on the production store carried a working token, from the 2026-09-01 run whose *own* token had expired. The store is readable by every lab user with SFTP access.

**Correction to the count this description first gave.** It said *"162 failures, 162 log lines, each with the full credential"*, inferring the line count from the run's failure count. Measured during the cleanup: **one occurrence on disk**, not 162. The code the old box was running predates #41 and returned a permanent verdict for any non-200 instead of raising, so it never reached the URL-bearing `HTTPError`; the single logged copy came from the recovery run under *current* code. The mechanism and the fix are unchanged — but on current code the blast radius is **one log line per failed pano**, so the same night after cutover would have written 161. The exposure that actually occurred was one line.

### The fix

Graph API v4 accepts `Authorization: OAuth <token>`, which keeps the secret out of the URL, and therefore out of the error text, the log file, and any intermediary's access log. Confirmed against the live API from the scraper box before changing anything: HTTP 200, `thumb_original_url` returned.

### On the test being non-vacuous

`_url_on_the_wire` builds the URL through requests' own `Request(...).prepare()`. Asserting on the bare `url` argument would pass either way — params are merged in at `prepare()` time, and that merge *is* the step that puts the token on the wire. Mutation-checked in both directions:

| mutation | result |
|---|---|
| `access_token` back in `params` | `test_the_metadata_url_never_carries_the_token` fails |
| `headers=` dropped entirely | `test_the_token_is_still_sent_as_an_oauth_header` fails |

The second matters because dropping auth altogether would satisfy "no token in the URL" while taking every Mapillary pano in the city down with a 401 the next night.

### Docs

`docs/downloader.md` advised setting the token *"in the crontab or an `EnvironmentFile`"* — which is how production ended up with it in plaintext in `crontab -l`. It now documents the `SHELL=/bin/bash` + `BASH_ENV` + mode-`600` pattern, including the caveat that under `/bin/sh` (dash) `BASH_ENV` is ignored and the token is simply unset — which fails as a *quiet* filtering-out of every Mapillary pano, not as an error.

### Already applied on the box (not in this PR)

The production crontab no longer holds the token: it is in `/home/ubuntu/.scraper.env` (mode 600) sourced via `BASH_ENV`, verified end to end by a throwaway cron line that echoed the variable's *length* from a real cron-spawned shell. The 52 city lines are untouched.

**Cleanup done separately (2026-09-03), not in this PR:** nine occurrences of the live token were redacted in place across both boxes — one in `richmond-va/scrape.log` on the store, two in staged/backup crontab files on the new box, and six on the retired box (its crontab, `.bash_history` ×4, and a crontab backup). Rotation was considered and deliberately declined by the repo owner; the redaction stands on its own.

Full suite: 1812 passed, 11 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])

