### PR TITLE
Write the 8192 px display copy beside every wide pano, and backfill the store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,9 @@ python3 log_analyzer/analyze.py [--no-download] [--city <city_id>] [--stale-days
 # One-off migrator for pre-v2 depth artifacts
 python3 migrate_depth_artifacts.py <storage-dir> [--dry-run]
 
+# One-off backfill of the display copy beside every wide pano (#115); idempotent, resumable. See docs/ops.md
+python3 downscale_panos.py <storage-dir> [--dry-run] [--max-runtime MINUTES] [--max-width PX]
+
 # One-off repair pass for fover-era panos (#73). Never backfills, never downgrades; see docs/ops.md
 python3 reports/scripts/pano_y_histogram.py <city-fqdn> --write-worklist
 python3 refetch_panos.py <storage-dir> (--worklist <csv.gz> | --from-store) [--dry-run] \
@@ -123,6 +126,8 @@ The README is a front door only; the reference material lives in `docs/` and eac
 
 **migrate_depth_artifacts.py** — offline, idempotent one-off that rewrites pre-v2 (x-mirrored, unversioned) depth artifacts into v2 column order. The scraper never revisits an existing artifact, so a store scraped before #58 keeps mirrored artifacts forever without this.
 
+**downscale_panos.py** (#115) — offline, idempotent, resumable backfill of the display copy `downloaders.common.write_downscaled_sidecar*` writes: `<pano_id>.w8192.jpg` beside every pano wider than the viewer's cap. Judges each pano from two JPEG headers (its own and its sidecar's), so a finished store decodes nothing; `--max-runtime` leaves the rest counted as `unreached`. The web app serves the sidecar in place of the native file and never cuts one itself — doing so OOM-killed prod JVMs (SidewalkWebpage#5239). Never fatal in the downloaders: a failed sidecar is logged and the native pano stays a success, because the native file is already the resume marker.
+
 **refetch_panos.py** — offline, idempotent one-off that re-fetches panos downloaded while the CBK URL carried `fover` (#73), recovering the polar-band resolution it cost. Same problem shape as the depth migrator — the scraper short-circuits on file existence, so nothing on the store is ever revisited — but with an inverted risk: the depth migrator rewrites an artifact it can fully reconstruct, while this one **replaces imagery that may be irreplaceable**, since ~52% of labelled panos no longer exist at Google. **The `fover` pass itself does not run** (decided 2026-09-05, `reports/2026-09-05-fover-refetch-pilot.md`): the 512-px polar bodies CBK serves without `fover` are server-side upscales of the 256-px ones, so there was never resolution to recover, and a quarter of the panos Google still serves have been re-rendered since scrape. The tool stays as a general, tested repair pass.
 1. Work-list in, from `reports/scripts/pano_y_histogram.py --write-worklist` (panos with a label in a half-res band, ~7.5% of Seattle's labelled panos) or `--from-store`. Read with `csv`+`gzip`, never pandas — same #46 reasoning as `progress_check`.
 2. `decide_without_fetching()` resolves `absent`/`unreadable`/`not_affected`/`already_clean`/`dims_changed` from the store alone, at **zero requests**, on every run — none of the five is ledgered. That is what makes a pass affordable, makes a re-run after a finished sweep free even if the ledger is lost (a repaired file's mtime is past `--fixed-after`), and means a wrong `--fixed-after` or a later `--allow-dims-change` can be corrected by re-running rather than by scrubbing rows. The `already_clean` gate is mtime-only, so it is load-bearing: a copy that reset mtimes makes every pano `already_clean`.
@@ -139,6 +144,7 @@ Everything lives under the storage root, with two-char pano-id prefix sharding:
 |------|------|
 | `<pano_id[:2]>/<pano_id>.jpg` | Stitched panorama |
 | `<pano_id[:2]>/<pano_id>.depth.npz` | Depth artifact (see below) |
+| `<pano_id[:2]>/<pano_id>.w8192.jpg` | Display copy of a pano wider than 8192 px (#115): the viewer's one-texture cap. Written by both downloaders beside the pano, backfilled by `downscale_panos.py`, and excluded by name from every walker that lists `*.jpg` |
 | `pano_id_log.csv` | Per-pano image ledger: `pano_id,downloaded` |
 | `depth_log.csv` | Per-pano depth ledger: `pano_id,saved\|unavailable` |
 | `log.csv` | One 18-column row per run |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ out of the panorama. It runs unattended every night, per city, across ~50 deploy
 | [`log_analyzer/analyze.py`](docs/log-analyzer.md) | Watches the nightly run across every city and exits nonzero when one looks broken. |
 | [`migrate_depth_artifacts.py`](docs/depth.md#migrating-a-pre-v2-store) | One-off, idempotent rewrite of depth artifacts written before the v2 format. |
 | [`refetch_panos.py`](docs/ops.md#repairing-fover-era-panoramas) | One-off, idempotent re-fetch of panoramas downloaded at half resolution, replacing one only when the replacement is strictly better. |
+| [`downscale_panos.py`](docs/ops.md#display-copies-of-wide-panoramas) | One-off, idempotent backfill of the 8192 px display copy the scraper now writes beside every wider panorama. |
 
 ## Quick start
 
@@ -77,6 +78,7 @@ One directory per city, sharded by the first two characters of the pano id:
 |---|---|
 | `<pano_id[:2]>/<pano_id>.jpg` | Stitched panorama |
 | `<pano_id[:2]>/<pano_id>.depth.npz` | Depth artifact |
+| `<pano_id[:2]>/<pano_id>.w8192.jpg` | Display copy of a panorama wider than 8192 px |
 | `pano_id_log.csv` | Image ledger — a row means the outcome is permanent |
 | `depth_log.csv` | Depth ledger — likewise |
 | `log.csv` | One 18-column row per run |

--- a/docs/downloader.md
+++ b/docs/downloader.md
@@ -6,8 +6,9 @@ this repo and runs nightly, per city, in production.
 
 A run has two phases:
 
-1. **Image phase** — stitch and save panorama JPEGs. Gated by [`pano_id_log.csv`](ops.md#resume-ledgers);
-   restricted to labeled panos unless `--all-panos`.
+1. **Image phase** — stitch and save panorama JPEGs, plus the 8192 px
+   [display copy](ops.md#display-copies-of-wide-panoramas) beside any panorama wider than that. Gated by
+   [`pano_id_log.csv`](ops.md#resume-ledgers); restricted to labeled panos unless `--all-panos`.
 2. **Depth phase** — one metadata request per unresolved pano, saving a `.depth.npz` artifact where Google has
    one. Gated by `depth_log.csv`. Always covers **every** pano, labeled or not. See [Depth maps](depth.md).
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -11,6 +11,7 @@ Everything lives under the storage root, sharded by the first two characters of 
 |---|---|
 | `<pano_id[:2]>/<pano_id>.jpg` | Stitched panorama |
 | `<pano_id[:2]>/<pano_id>.depth.npz` | [Depth artifact](depth.md#the-artifact) |
+| `<pano_id[:2]>/<pano_id>.w8192.jpg` | [Display copy](#display-copies-of-wide-panoramas) of a panorama wider than 8192 px |
 | `pano_id_log.csv` | Per-pano image ledger: `pano_id,downloaded` |
 | `depth_log.csv` | Per-pano depth ledger: `pano_id,saved\|unavailable` |
 | `log.csv` | One 18-column row per run |
@@ -24,6 +25,40 @@ order, and how long each city took — which no per-city log can, because none o
 
 `scrape.log` lives here rather than in the working directory on purpose: cron runs the scraper from whatever
 directory it likes, and a relative path scatters every per-pano failure detail somewhere nobody looks.
+
+### Display copies of wide panoramas
+
+The Project Sidewalk web app shows a stored panorama through Pannellum, which renders it as **one WebGL
+texture**, and 8192 px is a common `MAX_TEXTURE_SIZE`. A wider panorama — newer GSV imagery is 16384 × 8192,
+Richmond's Mapillary imagery 11000 — is therefore displayable only through a copy at that width. Both
+downloaders write it as a sidecar beside every wider panorama they store, `<pano_id>.w8192.jpg`, through the
+same `.part`-and-rename path as the panorama itself; a store that predates the sidecar is backfilled with
+
+```bash
+python3 downscale_panos.py <storage-dir> --dry-run          # count the missing copies, write nothing
+python3 downscale_panos.py <storage-dir>                    # write them
+python3 downscale_panos.py <storage-dir> --max-runtime 240  # a nightly-sized slice; the rest report as unreached
+```
+
+The copy is written here, not by the web app, because this is where the full raster already is. The app
+tried cutting it nightly from the stored JPEG and OOM-killed its own JVMs
+([SidewalkWebpage#5239](https://github.com/ProjectSidewalk/SidewalkWebpage/issues/5239)): Java's ImageIO has
+no DCT-domain scaling and re-decodes the file once per strip, ~10 s and ~400 MB of heap per panorama inside a
+1.5 GB web-app heap. Pillow's `draft()` decodes a 16384-wide JPEG straight to half size in 0.8 s and ~150 MB,
+which is what the backfill uses; the downloaders resize the raster they already hold.
+
+Three things about the sidecar are load-bearing:
+
+* **The width is in the name.** The web app looks for exactly the name its own configured cap produces
+  (`pano.downscaled.max-width`, 8192), and checks the header before serving it, so a change of cap is a new
+  sidecar rather than an ambiguous overwrite — change `DOWNSCALED_MAX_WIDTH` in `downloaders/common.py` and
+  the app's setting together, then re-run the backfill.
+* **A sidecar is never a panorama.** Everything that lists `*.jpg` in a shard — `refetch_panos.py
+  --from-store`, the backfill's own walk — excludes it by name (`is_downscaled_sidecar`). The cropper never
+  sees one: crops are always cut from the native file, by exact path.
+* **A failed sidecar never fails the panorama.** By the time it is written the native file is in place and is
+  the [resume marker](#resume-ledgers); raising would re-attempt the pano every night, skip it at the exists()
+  check, and never write the copy. The failure is logged to `scrape.log`, and the backfill heals it.
 
 ## Resume ledgers
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -46,6 +46,7 @@ Two settings there are load-bearing, and losing either shows up as a *lower numb
 | The nightly queue: manifest parsing, ordering and rotation, both budgets, the lock, exit codes | `test_scrape_queue.py` |
 | Log analyzer, and that its column list moves with the writer's | `test_log_analyzer.py` |
 | The offline depth-artifact migrator | `test_migrate_depth_artifacts.py` |
+| The display copy of a wide panorama: naming, the two writers, both downloaders' hooks, the store walkers' blindness to it, and the backfill sweep | `test_downscaled_sidecar.py` |
 | The [`fover` repair pass](ops.md#repairing-fover-era-panoramas): the decision table, the byte-for-byte survival of every refusal, ledger semantics, the recovery metric, and the CLI surface | `test_refetch_panos.py` |
 | The desk studies under `reports/scripts/`, and the artifacts they commit | `test_*_census.py`, `test_*_study.py`, `test_studyfmt.py`, `test_committed_data_files.py`, `test_reports_index.py` |
 | That the docs' internal links and anchors resolve, and that cited `docs/` paths exist | `test_docs.py` |

--- a/downloaders/common.py
+++ b/downloaders/common.py
@@ -1,7 +1,10 @@
 import contextlib
 import enum
 import os
+import re
 import struct
+
+from PIL import Image
 
 # Start-of-frame markers whose payload carries the image dimensions. DHT/DAC/RST/SOS are excluded;
 # 0xC4/0xC8/0xCC look like SOF numerically and are not.
@@ -103,3 +106,92 @@ def atomic_output_path(final_path, mode=0o664):
         except OSError:
             pass
         raise
+
+
+# --- Display copies of wide panoramas (#115) -------------------------------------------------------------
+#
+# The Project Sidewalk web app shows a stored pano through Pannellum, which renders an equirectangular image
+# as ONE WebGL texture, and 8192 px is a common MAX_TEXTURE_SIZE. A wider pano - newer GSV is 16384 x 8192,
+# Richmond's Mapillary imagery 11000 - is therefore displayable only through a copy at this width. The copy
+# is written here, beside the native file, because this is where the full raster already is: the web app
+# tried cutting it nightly from the stored JPEG and OOM-killed its own JVMs (SidewalkWebpage#5239). ImageIO
+# has no DCT-domain scaling and re-decodes the file once per strip, ~10 s and ~400 MB of heap per pano,
+# inside a 1.5 GB web-app heap; Pillow's draft() decodes straight to half size in 0.8 s and ~150 MB.
+#
+# The width is in the file name, so a change of cap is a new sidecar rather than an ambiguous overwrite,
+# and the web app looks for exactly the name its own configured cap produces. Every walker that lists the
+# store's `*.jpg` has to ask is_downscaled_sidecar(), or a sidecar's stem is taken for a pano id.
+DOWNSCALED_MAX_WIDTH = 8192
+
+#: Display copies are looked at in a viewer, never cut from: crops always come from the native file.
+DOWNSCALED_JPEG_QUALITY = 85
+
+_SIDECAR_SUFFIX = re.compile(r'\.w(\d+)\.jpg$')
+
+
+def downscaled_sidecar_path(pano_path, max_width=None):
+    """'<pano stem>.w<max_width>.jpg', beside the pano."""
+    if max_width is None:
+        max_width = DOWNSCALED_MAX_WIDTH
+    stem, _ = os.path.splitext(pano_path)
+    return '%s.w%d.jpg' % (stem, max_width)
+
+
+def is_downscaled_sidecar(filename):
+    """Whether a store filename is a display copy rather than a panorama."""
+    return _SIDECAR_SUFFIX.search(os.path.basename(filename)) is not None
+
+
+def downscaled_size(width, height, max_width):
+    """The size of a `max_width`-wide copy of a width x height image: aspect kept, never upscaled."""
+    if width <= max_width:
+        return width, height
+    return max_width, max(1, int(round(height * max_width / float(width))))
+
+
+def _write_reduced(image, size, path, quality):
+    reduced = image if image.size == size else image.resize(size, Image.BOX)
+    with atomic_output_path(path) as tmp_path:
+        reduced.save(tmp_path, 'jpeg', quality=quality)
+    return path
+
+
+def write_downscaled_sidecar(image, pano_path, max_width=None, quality=None):
+    """Write the display copy of an in-memory pano, or nothing when it is already narrow enough.
+
+    Area-averaged (Image.BOX): each output pixel is the mean of the source pixels it covers - the right
+    filter for a large reduction and, at the 2:1 GSV case, exactly the 2 x 2 block mean.
+
+    @return The sidecar's path, or None when no copy was needed.
+    """
+    max_width = DOWNSCALED_MAX_WIDTH if max_width is None else max_width
+    quality = DOWNSCALED_JPEG_QUALITY if quality is None else quality
+    if image.width <= max_width:
+        return None
+    return _write_reduced(image, downscaled_size(image.width, image.height, max_width),
+                          downscaled_sidecar_path(pano_path, max_width), quality)
+
+
+def write_downscaled_sidecar_from_file(pano_path, max_width=None, quality=None):
+    """The same copy, from a pano on disk: what the backfill and the Mapillary path use.
+
+    `Image.draft` asks libjpeg to decode in the DCT domain at the largest power-of-two reduction that still
+    meets the target, so a 16384-wide pano is decoded straight to 8192 and the full raster never exists -
+    measured on a real 16384 x 8192 pano at 0.8 s and ~150 MB, against 2.3 s and ~900 MB for a full decode.
+    BOX then covers whatever draft could not reach exactly (11000 -> 8192 decodes at full size).
+
+    @return The sidecar's path, or None when the pano is not wider than the cap.
+    @raise  ValueError when the file is not a readable JPEG; the caller decides what that means.
+    """
+    max_width = DOWNSCALED_MAX_WIDTH if max_width is None else max_width
+    quality = DOWNSCALED_JPEG_QUALITY if quality is None else quality
+    dims = jpeg_dimensions(pano_path)
+    if dims is None:
+        raise ValueError('%s is not a readable JPEG' % pano_path)
+    if dims[0] <= max_width:
+        return None
+    size = downscaled_size(dims[0], dims[1], max_width)
+    with Image.open(pano_path) as image:
+        image.draft('RGB', size)
+        image.load()
+        return _write_reduced(image, size, downscaled_sidecar_path(pano_path, max_width), quality)

--- a/downloaders/gsv.py
+++ b/downloaders/gsv.py
@@ -45,7 +45,7 @@ except ImportError:
     depth_start_interval = depth_min_request_interval
     depth_max_request_interval = 30.0
 
-from .common import DownloadResult, atomic_output_path
+from .common import DownloadResult, atomic_output_path, write_downscaled_sidecar
 
 
 def _normalize_proxies(raw):
@@ -498,6 +498,19 @@ def fetch_pano_image(pano_id, width, height, zoom):
     return StitchedPano(image, degraded, upscaled)
 
 
+def _write_display_copy(image, out_image_name, pano_id):
+    """The viewer's copy of a pano too wide for one WebGL texture (#115), beside the native file.
+
+    Never fatal. The native file is already in place and IS the resume marker, so raising here would turn a
+    downloaded pano into a transient failure: re-attempted next run, skipped at the exists() check, and no
+    sidecar ever written. Logged instead, and downscale_panos.py's sweep heals the gap.
+    """
+    try:
+        write_downscaled_sidecar(image, out_image_name)
+    except Exception as e:
+        logging.error("IMAGEDOWNLOAD: pano %s: display copy not written: %r", pano_id, e)
+
+
 def download_single_pano(storage_path, pano_info):
     pano_id = pano_info['pano_id']
 
@@ -530,6 +543,7 @@ def download_single_pano(storage_path, pano_info):
     # would otherwise leave a truncated .jpg that every later run reports as a completed download.
     with atomic_output_path(out_image_name) as tmp_path:
         stitched.image.save(tmp_path, 'jpeg')
+    _write_display_copy(stitched.image, out_image_name, pano_id)
 
     # log.csv column 8 (#52 item 2): the JPEG on disk holds less imagery than its dimensions advertise. See
     # fetch_pano_image for why the test is not `zoom == 3`.

--- a/downloaders/mapillary.py
+++ b/downloaders/mapillary.py
@@ -12,7 +12,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from .common import DownloadResult, atomic_output_path, jpeg_dimensions
+from .common import DownloadResult, atomic_output_path, jpeg_dimensions, write_downscaled_sidecar_from_file
 
 GRAPH_API_BASE = 'https://graph.mapillary.com'
 TOKEN_ENV_VAR = 'MAPILLARY_ACCESS_TOKEN'
@@ -298,4 +298,11 @@ def download_single_pano(storage_path, pano_info):
             # a short read raises out of iter_content before this line, and the .part never lands.
             if jpeg_dimensions(tmp_path) is None:
                 raise MapillaryErrorResponse("Mapillary image response for %s was not a JPEG" % pano_id)
+    # The display copy for a pano wider than one WebGL texture (#115). From the file rather than a raster -
+    # this path never decodes the image - and never fatal, for the reason gsv._write_display_copy gives:
+    # the native file is already the resume marker, and downscale_panos.py heals a missing sidecar.
+    try:
+        write_downscaled_sidecar_from_file(out_image_name)
+    except Exception as e:
+        logging.error("Mapillary pano %s: display copy not written: %r", pano_id, e)
     return DownloadResult.success

--- a/downscale_panos.py
+++ b/downscale_panos.py
@@ -1,0 +1,134 @@
+# !/usr/bin/python3
+"""Write the display copy of every stored panorama wider than the viewer's cap (#115).
+
+The Project Sidewalk web app shows a stored pano through Pannellum, which renders it as one WebGL texture,
+and 8192 px is a common MAX_TEXTURE_SIZE; a wider pano is displayable only through a copy at that width.
+The nightly scraper writes that copy beside every new wide pano it stores (`downloaders.common`), but the
+store predates the sidecar, so this sweep writes the missing ones: `<pano_id[:2]>/<pano_id>.w8192.jpg` for
+every `<pano_id>.jpg` wider than the cap whose sidecar is absent or not at the cap.
+
+Idempotent and resumable: a pano is judged from two JPEG headers (its own, and its sidecar's if there is
+one), so re-running over a finished store decodes nothing, and a run cut short by `--max-runtime` picks up
+where it left off next time. Run it directly on the host that owns the store rather than over sshfs: the
+work is a full JPEG decode per wide pano, ~0.8 s each with Pillow's DCT-domain draft, and the read is the
+part sshfs makes slow.
+
+Usage:
+    python3 downscale_panos.py <storage_path> [--dry-run] [--max-runtime MINUTES] [--max-width PX]
+"""
+
+import argparse
+import os
+import time
+from collections import namedtuple
+
+from PIL import Image
+
+from downloaders.common import (DOWNSCALED_MAX_WIDTH, downscaled_sidecar_path, is_downscaled_sidecar,
+                                jpeg_dimensions, write_downscaled_sidecar_from_file)
+
+# 'written' counts sidecars written - or, under --dry-run, sidecars that would have been. 'current' is a
+# sidecar already at the cap, 'narrow' a pano the viewer can take as it is, 'unreached' a pano the runtime
+# budget left unexamined: the count that says how much a nightly-sized slice has left to do.
+Summary = namedtuple('Summary', ['scanned', 'written', 'narrow', 'current', 'failed', 'unreached'])
+
+
+def find_panos(storage_path):
+    """Yield every stored panorama's path, in a stable order.
+
+    Same shape as refetch_panos.walk_store: only `<2 chars>/<id>.jpg` with the shard matching id[:2] is a
+    pano. A sidecar beside it carries the same prefix and suffix, so it is excluded by name, and a `.part`
+    left by a crashed writer is not a JPEG at all.
+    """
+    for shard in sorted(os.listdir(storage_path)):
+        shard_path = os.path.join(storage_path, shard)
+        if len(shard) != 2 or not os.path.isdir(shard_path):
+            continue
+        for filename in sorted(os.listdir(shard_path)):
+            if filename.endswith('.jpg') and filename[:2] == shard and not is_downscaled_sidecar(filename):
+                yield os.path.join(shard_path, filename)
+
+
+def sidecar_is_current(pano_path, max_width):
+    """Whether the pano's sidecar exists and is at the cap. The name promises the width; the header proves it,
+    so a truncated or mis-sized copy is rewritten rather than trusted."""
+    dims = jpeg_dimensions(downscaled_sidecar_path(pano_path, max_width))
+    return dims is not None and dims[0] == max_width
+
+
+def downscale_store(storage_path, dry_run=False, max_width=None, max_runtime_minutes=None):
+    """Sweep storage_path and write every missing display copy; see the module docstring.
+
+    @param storage_path        Root of one city's pano store (the directory holding the 2-char shard dirs).
+    @param dry_run             Report what would be written without decoding or writing anything.
+    @param max_width           The viewer's cap; DOWNSCALED_MAX_WIDTH in production, smaller in a test.
+    @param max_runtime_minutes Stop examining panos after this long; the rest are counted as unreached.
+    @return                    Summary(scanned, written, narrow, current, failed, unreached).
+    """
+    max_width = DOWNSCALED_MAX_WIDTH if max_width is None else max_width
+    started = time.monotonic()
+    scanned = written = narrow = current = failed = unreached = 0
+    for path in find_panos(storage_path):
+        if max_runtime_minutes is not None and time.monotonic() - started >= max_runtime_minutes * 60:
+            unreached += 1
+            continue
+        scanned += 1
+        dims = jpeg_dimensions(path)
+        if dims is None:
+            # A truncated or foreign file: report it and leave the bytes for a human, and keep going - one bad
+            # pano must not stop a sweep of a multi-terabyte store.
+            failed += 1
+            print("FAILED %s: not a readable JPEG" % path)
+            continue
+        if dims[0] <= max_width:
+            narrow += 1
+            continue
+        if sidecar_is_current(path, max_width):
+            current += 1
+            continue
+        try:
+            if not dry_run:
+                write_downscaled_sidecar_from_file(path, max_width)
+            written += 1
+            print("%s %s" % ('Would write' if dry_run else 'Wrote', downscaled_sidecar_path(path, max_width)))
+        except Exception as e:
+            failed += 1
+            print("FAILED %s: %s" % (path, e))
+    return Summary(scanned, written, narrow, current, failed, unreached)
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description='Write the %d px display copy of every stored panorama wider than that, beside it as '
+                    '<pano_id>.w%d.jpg. Idempotent: a pano whose copy is already at the cap is skipped from '
+                    'its headers alone, so re-running on a finished store changes nothing.'
+                    % (DOWNSCALED_MAX_WIDTH, DOWNSCALED_MAX_WIDTH))
+    parser.add_argument('storage_path',
+                        help='Root of one city\'s pano store - the directory holding the 2-char shard dirs.')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Only report which copies would be written; decode and write nothing.')
+    parser.add_argument('--max-runtime', type=float, default=None, metavar='MINUTES',
+                        help='Stop examining panos after this many minutes; the rest are reported as unreached '
+                             'and picked up by the next run.')
+    parser.add_argument('--max-width', type=int, default=DOWNSCALED_MAX_WIDTH, metavar='PX',
+                        help='The viewer\'s cap (default %d). The web app looks for exactly the width its own '
+                             'configuration names, so change this only together with it.' % DOWNSCALED_MAX_WIDTH)
+    return parser
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    # Process-level policy, as in CropRunner.main: a 16384 x 8192 pano is 134 MP, over Pillow's 89 MP
+    # decompression-bomb warning threshold, and this script exists to open exactly those files.
+    Image.MAX_IMAGE_PIXELS = None
+
+    summary = downscale_store(args.storage_path, dry_run=args.dry_run, max_width=args.max_width,
+                              max_runtime_minutes=args.max_runtime)
+    print("Examined %d panorama(s): %d %s, %d under the cap, %d already had a copy, %d failed, %d unreached."
+          % (summary.scanned, summary.written, 'would be written' if args.dry_run else 'written',
+             summary.narrow, summary.current, summary.failed, summary.unreached))
+    return 1 if summary.failed else 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/refetch_panos.py
+++ b/refetch_panos.py
@@ -59,7 +59,7 @@ import time
 from collections import Counter
 
 from downloaders import gsv
-from downloaders.common import atomic_output_path, jpeg_dimensions
+from downloaders.common import atomic_output_path, jpeg_dimensions, is_downscaled_sidecar
 
 # The band was only ever a zoom-5 effect: a panorama whose own max zoom is 3 or 4 was served at full size at
 # every level (measured on a 2007 DC panorama in reports/2026-08-07-cbk-tile-resolution.md, finding 1). So a
@@ -265,9 +265,9 @@ def walk_store(storage_path):
 
     Only `<storage_path>/<2 chars>/<id>.jpg` with the shard matching id[:2] counts - the layout
     download_single_pano writes and _stored_path reads back. Anything else carrying a .jpg suffix under the
-    root (a crops tree, a stray file at the top level) is not a panorama, and listing it would hand
-    decide_without_fetching an id whose reconstructed path does not exist: an `absent` for something that
-    was never a pano, one summary line of noise per file.
+    root (a crops tree, a stray file at the top level, a `.w8192.jpg` display copy beside its pano, #115) is
+    not a panorama, and listing it would hand decide_without_fetching an id whose reconstructed path does
+    not exist: an `absent` for something that was never a pano, one summary line of noise per file.
     """
     rows = []
     for shard in sorted(os.listdir(storage_path)):
@@ -275,7 +275,7 @@ def walk_store(storage_path):
         if len(shard) != 2 or not os.path.isdir(shard_path):
             continue
         for filename in sorted(os.listdir(shard_path)):
-            if filename.endswith('.jpg') and filename[:2] == shard:
+            if filename.endswith('.jpg') and filename[:2] == shard and not is_downscaled_sidecar(filename):
                 rows.append({'pano_id': filename[:-len('.jpg')]})
     return rows
 

--- a/tests/test_coverage_config.py
+++ b/tests/test_coverage_config.py
@@ -25,6 +25,7 @@ PRODUCTION_MODULES = {
     'downloaders/common.py',
     'downloaders/gsv.py',
     'downloaders/mapillary.py',
+    'downscale_panos.py',
     'log_analyzer/analyze.py',
     'migrate_depth_artifacts.py',
     'refetch_panos.py',

--- a/tests/test_csv_intake.py
+++ b/tests/test_csv_intake.py
@@ -554,7 +554,8 @@ class TestJsonToCsvConversion:
 # Everything the scraper or the cropper runs. log_analyzer/ and reports/scripts/ are deliberately
 # absent: both still use pandas, and both are dev/ops tools rather than production code.
 PRODUCTION_MODULES = ['DownloadRunner.py', 'CropRunner.py', 'config.py', 'scrape_queue.py',
-                      'migrate_depth_artifacts.py', 'refetch_panos.py', 'flag_panos/json_to_csv.py',
+                      'migrate_depth_artifacts.py', 'refetch_panos.py', 'downscale_panos.py',
+                      'flag_panos/json_to_csv.py',
                       'downloaders/__init__.py', 'downloaders/common.py',
                       'downloaders/gsv.py', 'downloaders/mapillary.py']
 

--- a/tests/test_downscaled_sidecar.py
+++ b/tests/test_downscaled_sidecar.py
@@ -1,0 +1,355 @@
+"""The display copy of a wide panorama (#115): the `<pano_id>.w<cap>.jpg` sidecar the scraper writes beside
+a pano wider than the viewer's cap, and the sweep that backfills it across a store.
+
+The cap is patched down to 1024 throughout, so a 2048-wide fixture is "wide" and no test allocates a
+16384 x 8192 raster. Every case that reads pixels back uses a two-tone image - red left, blue right - so a
+copy that was resized correctly is distinguishable from one that was cropped, or padded, or mirrored.
+"""
+
+import io
+import logging
+import os
+
+import pytest
+from PIL import Image
+
+from downloaders import common, gsv, mapillary
+from downloaders.common import DownloadResult
+import downscale_panos
+import refetch_panos
+from test_gsv_stitcher import stub_probe, stub_tiles, jpeg_bytes as tile_bytes, RED, BLUE, assert_color
+from test_image_downloaders import FakeResponse, FakeSession, HEALTHY_MAPILLARY_METADATA, MAPILLARY_PANO
+
+CAP = 1024
+
+
+def two_tone(width, height):
+    image = Image.new('RGB', (width, height), RED)
+    image.paste(BLUE, (width // 2, 0, width, height))
+    return image
+
+
+def two_tone_jpeg(path, width, height):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    two_tone(width, height).save(path, 'jpeg', quality=95)
+    return path
+
+
+def assert_two_tone(path, size):
+    with Image.open(path) as image:
+        assert image.size == size
+        w, h = size
+        assert_color(image.getpixel((w // 4, h // 2)), RED)
+        assert_color(image.getpixel((3 * w // 4, h // 2)), BLUE)
+
+
+@pytest.fixture
+def small_cap(monkeypatch):
+    """The production cap read at call time, so the downloaders see it without threading a parameter."""
+    monkeypatch.setattr(common, 'DOWNSCALED_MAX_WIDTH', CAP)
+
+
+class TestNaming:
+    def test_the_sidecar_sits_beside_the_pano_and_carries_the_cap(self):
+        assert common.downscaled_sidecar_path('/store/ab/abcdef.jpg') == '/store/ab/abcdef.w8192.jpg'
+        assert common.downscaled_sidecar_path('/store/ab/abcdef.jpg', 1024) == '/store/ab/abcdef.w1024.jpg'
+
+    def test_the_default_is_the_production_cap(self):
+        assert common.DOWNSCALED_MAX_WIDTH == 8192, 'the web app looks for .w8192.jpg; change both or neither'
+
+    @pytest.mark.parametrize('name, expected', [
+        ('abcdef.w8192.jpg', True),
+        ('/store/ab/abcdef.w1024.jpg', True),
+        ('abcdef.jpg', False),
+        ('abcdef.depth.npz', False),
+        ('abcdefw8192.jpg', False),   # no dot: some pano id that happens to end in w8192
+        ('abcdef.w8192.jpg.part', False),
+    ])
+    def test_is_downscaled_sidecar_recognises_exactly_the_suffix(self, name, expected):
+        assert common.is_downscaled_sidecar(name) is expected
+
+    @pytest.mark.parametrize('dims, expected', [
+        ((16384, 8192), (8192, 4096)),   # newer GSV: an exact 2:1
+        ((11000, 5500), (8192, 4096)),   # Richmond's Mapillary imagery: not a power of two
+        ((11000, 5501), (8192, 4097)),   # rounds, never truncates
+        ((8192, 4096), (8192, 4096)),    # at the cap: untouched
+        ((3328, 1664), (3328, 1664)),    # under it: never upscaled
+    ])
+    def test_downscaled_size_keeps_the_aspect_and_never_upscales(self, dims, expected):
+        assert common.downscaled_size(dims[0], dims[1], 8192) == expected
+
+
+class TestWriteFromARaster:
+    def test_a_wide_image_gets_an_area_averaged_copy_at_the_cap(self, tmp_path):
+        pano = str(tmp_path / 'ab' / 'abcdef.jpg')
+        os.makedirs(os.path.dirname(pano))
+
+        written = common.write_downscaled_sidecar(two_tone(2048, 1024), pano, max_width=CAP)
+
+        assert written == str(tmp_path / 'ab' / 'abcdef.w1024.jpg')
+        assert_two_tone(written, (CAP, 512))
+        assert sorted(os.listdir(tmp_path / 'ab')) == ['abcdef.w1024.jpg'], 'no .part left behind'
+
+    def test_a_narrow_image_gets_nothing(self, tmp_path):
+        pano = str(tmp_path / 'ab' / 'abcdef.jpg')
+        os.makedirs(os.path.dirname(pano))
+
+        assert common.write_downscaled_sidecar(two_tone(CAP, 512), pano, max_width=CAP) is None
+        assert os.listdir(tmp_path / 'ab') == []
+
+    def test_the_copy_is_written_atomically(self, tmp_path, monkeypatch):
+        """A crashed write must not leave a file the web app would serve as a texture."""
+        pano = str(tmp_path / 'ab' / 'abcdef.jpg')
+        os.makedirs(os.path.dirname(pano))
+
+        def full_disk(self, fp, *args, **kwargs):
+            with open(fp, 'wb') as f:
+                f.write(b'\xff\xd8 truncated')
+            raise OSError(28, 'No space left on device')
+
+        monkeypatch.setattr(Image.Image, 'save', full_disk)
+        with pytest.raises(OSError):
+            common.write_downscaled_sidecar(two_tone(2048, 1024), pano, max_width=CAP)
+        assert os.listdir(tmp_path / 'ab') == []
+
+    def test_quality_is_the_display_setting_by_default(self, tmp_path):
+        """A display copy at 85, not Pillow's 75: it is looked at full-screen, never cut from."""
+        pano = str(tmp_path / 'ab' / 'abcdef.jpg')
+        os.makedirs(os.path.dirname(pano))
+        noise = Image.effect_noise((2048, 1024), 64).convert('RGB')
+
+        default = os.path.getsize(common.write_downscaled_sidecar(noise, pano, max_width=CAP))
+        low = os.path.getsize(common.write_downscaled_sidecar(noise, pano, max_width=CAP, quality=50))
+
+        assert common.DOWNSCALED_JPEG_QUALITY == 85
+        assert default > low
+
+
+class TestWriteFromAFile:
+    def test_a_wide_pano_on_disk_gets_its_copy(self, tmp_path):
+        pano = two_tone_jpeg(str(tmp_path / 'ab' / 'abcdef.jpg'), 2048, 1024)
+
+        written = common.write_downscaled_sidecar_from_file(pano, max_width=CAP)
+
+        assert written == str(tmp_path / 'ab' / 'abcdef.w1024.jpg')
+        assert_two_tone(written, (CAP, 512))
+
+    def test_a_ratio_draft_cannot_reach_is_finished_by_resize(self, tmp_path):
+        """draft() only decodes at 1/2, 1/4, 1/8; 2048 -> 768 is none of those, so BOX covers the rest."""
+        pano = two_tone_jpeg(str(tmp_path / 'ab' / 'abcdef.jpg'), 2048, 1024)
+
+        written = common.write_downscaled_sidecar_from_file(pano, max_width=768)
+
+        assert written.endswith('.w768.jpg')
+        assert_two_tone(written, (768, 384))
+
+    def test_a_narrow_pano_gets_nothing(self, tmp_path):
+        pano = two_tone_jpeg(str(tmp_path / 'ab' / 'abcdef.jpg'), CAP, 512)
+        assert common.write_downscaled_sidecar_from_file(pano, max_width=CAP) is None
+        assert os.listdir(tmp_path / 'ab') == ['abcdef.jpg']
+
+    def test_a_file_that_is_not_a_jpeg_raises(self, tmp_path):
+        pano = tmp_path / 'ab' / 'abcdef.jpg'
+        pano.parent.mkdir()
+        pano.write_bytes(b'<html>not an image</html>')
+        with pytest.raises(ValueError):
+            common.write_downscaled_sidecar_from_file(str(pano), max_width=CAP)
+
+
+class TestTheGsvDownloaderWritesTheCopy:
+    def pano_info(self, width, height, pano_id='wideStitchAAAAAAAAAAAA'):
+        return {'pano_id': pano_id, 'width': width, 'height': height}
+
+    def test_a_wide_stitch_lands_with_its_copy(self, tmp_path, monkeypatch, small_cap):
+        stub_probe(monkeypatch, pick_zoom=5)
+        stub_tiles(monkeypatch, lambda tile: (tile[0], tile[1], tile_bytes(RED if tile[0] < 2 else BLUE)))
+
+        assert gsv.download_single_pano(str(tmp_path), self.pano_info(2048, 1024)) == DownloadResult.success
+
+        shard = tmp_path / 'wi'
+        assert sorted(os.listdir(shard)) == ['wideStitchAAAAAAAAAAAA.jpg', 'wideStitchAAAAAAAAAAAA.w1024.jpg']
+        assert_two_tone(str(shard / 'wideStitchAAAAAAAAAAAA.w1024.jpg'), (CAP, 512))
+
+    def test_a_pano_under_the_cap_lands_alone(self, tmp_path, monkeypatch, small_cap):
+        stub_probe(monkeypatch, pick_zoom=5)
+        stub_tiles(monkeypatch, lambda tile: (tile[0], tile[1], tile_bytes(RED)))
+
+        assert gsv.download_single_pano(str(tmp_path), self.pano_info(CAP, 512)) == DownloadResult.success
+
+        assert os.listdir(tmp_path / 'wi') == ['wideStitchAAAAAAAAAAAA.jpg']
+
+    def test_a_failed_copy_does_not_fail_the_pano(self, tmp_path, monkeypatch, small_cap, caplog):
+        """The native file is already the resume marker. Raising here would re-attempt the pano every night,
+        skip it at the exists() check, and never write the copy; the sweep is what heals it."""
+        stub_probe(monkeypatch, pick_zoom=5)
+        stub_tiles(monkeypatch, lambda tile: (tile[0], tile[1], tile_bytes(RED)))
+
+        def refuse(image, pano_path, max_width=None, quality=None):
+            raise OSError(28, 'No space left on device')
+
+        monkeypatch.setattr(gsv, 'write_downscaled_sidecar', refuse)
+        with caplog.at_level(logging.ERROR):
+            result = gsv.download_single_pano(str(tmp_path), self.pano_info(2048, 1024))
+
+        assert result == DownloadResult.success
+        assert os.listdir(tmp_path / 'wi') == ['wideStitchAAAAAAAAAAAA.jpg']
+        assert 'display copy not written' in caplog.text
+        assert 'wideStitchAAAAAAAAAAAA' in caplog.text
+
+
+class TestTheMapillaryDownloaderWritesTheCopy:
+    @pytest.fixture
+    def token(self, monkeypatch):
+        monkeypatch.setenv(mapillary.TOKEN_ENV_VAR, 'test-token')
+
+    def wide_body(self):
+        buf = io.BytesIO()
+        two_tone(2048, 1024).save(buf, 'jpeg', quality=95)
+        return buf.getvalue()
+
+    def test_a_wide_download_lands_with_its_copy(self, tmp_path, monkeypatch, small_cap, token):
+        session = FakeSession(FakeResponse(payload=HEALTHY_MAPILLARY_METADATA),
+                              FakeResponse(chunks=[self.wide_body()]))
+        monkeypatch.setattr(mapillary, '_session', lambda: session)
+
+        assert mapillary.download_single_pano(str(tmp_path), MAPILLARY_PANO) == DownloadResult.success
+
+        pano_id = MAPILLARY_PANO['pano_id']
+        shard = tmp_path / pano_id[:2]
+        assert sorted(os.listdir(shard)) == ['%s.jpg' % pano_id, '%s.w1024.jpg' % pano_id]
+        assert_two_tone(str(shard / ('%s.w1024.jpg' % pano_id)), (CAP, 512))
+
+    def test_a_failed_copy_does_not_fail_the_pano(self, tmp_path, monkeypatch, small_cap, token, caplog):
+        session = FakeSession(FakeResponse(payload=HEALTHY_MAPILLARY_METADATA),
+                              FakeResponse(chunks=[self.wide_body()]))
+        monkeypatch.setattr(mapillary, '_session', lambda: session)
+
+        def refuse(pano_path, max_width=None, quality=None):
+            raise OSError(28, 'No space left on device')
+
+        monkeypatch.setattr(mapillary, 'write_downscaled_sidecar_from_file', refuse)
+        with caplog.at_level(logging.ERROR):
+            result = mapillary.download_single_pano(str(tmp_path), MAPILLARY_PANO)
+
+        assert result == DownloadResult.success
+        assert os.listdir(tmp_path / MAPILLARY_PANO['pano_id'][:2]) == ['%s.jpg' % MAPILLARY_PANO['pano_id']]
+        assert 'display copy not written' in caplog.text
+
+
+class TestTheStoreWalkersIgnoreTheCopy:
+    def test_refetch_panos_does_not_take_a_sidecar_for_a_panorama(self, tmp_path):
+        two_tone_jpeg(str(tmp_path / 'aa' / 'aaBBccDDeeFFggHHiiJJ.jpg'), 16, 8)
+        two_tone_jpeg(str(tmp_path / 'aa' / 'aaBBccDDeeFFggHHiiJJ.w8192.jpg'), 16, 8)
+
+        assert [r['pano_id'] for r in refetch_panos.walk_store(str(tmp_path))] == ['aaBBccDDeeFFggHHiiJJ']
+
+    def test_the_sweep_does_not_either(self, tmp_path):
+        two_tone_jpeg(str(tmp_path / 'aa' / 'aaBBccDDeeFFggHHiiJJ.jpg'), 16, 8)
+        two_tone_jpeg(str(tmp_path / 'aa' / 'aaBBccDDeeFFggHHiiJJ.w8192.jpg'), 16, 8)
+        (tmp_path / 'aa' / 'aaBBccDDeeFFggHHiiJJ.jpg.part').write_bytes(b'\xff\xd8')
+        (tmp_path / 'aa' / 'zzWrongShardXXXXXXXX.jpg').write_bytes(b'\xff\xd8')
+        (tmp_path / 'stray.jpg').write_bytes(b'\xff\xd8')
+        (tmp_path / 'log.csv').write_text('a,b\n')
+
+        assert list(downscale_panos.find_panos(str(tmp_path))) == \
+            [str(tmp_path / 'aa' / 'aaBBccDDeeFFggHHiiJJ.jpg')]
+
+
+class TestTheSweep:
+    """One store that reaches every branch: a wide pano with no copy, one whose copy is already at the cap,
+    one whose copy is at another width, a narrow pano, and a file that is not a JPEG."""
+
+    def seed(self, tmp_path):
+        store = str(tmp_path)
+        two_tone_jpeg(os.path.join(store, 'aa', 'aaMissingCopyAAAAAAA.jpg'), 2048, 1024)
+        two_tone_jpeg(os.path.join(store, 'bb', 'bbCurrentCopyAAAAAAA.jpg'), 2048, 1024)
+        two_tone_jpeg(os.path.join(store, 'bb', 'bbCurrentCopyAAAAAAA.w1024.jpg'), CAP, 512)
+        two_tone_jpeg(os.path.join(store, 'cc', 'ccStaleCopyAAAAAAAAA.jpg'), 2048, 1024)
+        two_tone_jpeg(os.path.join(store, 'cc', 'ccStaleCopyAAAAAAAAA.w1024.jpg'), 512, 256)
+        two_tone_jpeg(os.path.join(store, 'dd', 'ddNarrowAAAAAAAAAAAA.jpg'), CAP, 512)
+        os.makedirs(os.path.join(store, 'ee'))
+        with open(os.path.join(store, 'ee', 'eeNotAJpegAAAAAAAAAA.jpg'), 'wb') as f:
+            f.write(b'<html>not an image</html>')
+        return store
+
+    def test_it_writes_exactly_the_missing_and_stale_copies(self, tmp_path, capsys):
+        store = self.seed(tmp_path)
+
+        summary = downscale_panos.downscale_store(store, max_width=CAP)
+
+        assert summary == downscale_panos.Summary(scanned=5, written=2, narrow=1, current=1, failed=1,
+                                                  unreached=0)
+        assert_two_tone(os.path.join(store, 'aa', 'aaMissingCopyAAAAAAA.w1024.jpg'), (CAP, 512))
+        assert_two_tone(os.path.join(store, 'cc', 'ccStaleCopyAAAAAAAAA.w1024.jpg'), (CAP, 512))
+        # The current copy is left byte-for-byte alone: nothing decoded it.
+        with Image.open(os.path.join(store, 'bb', 'bbCurrentCopyAAAAAAA.w1024.jpg')) as image:
+            assert image.size == (CAP, 512)
+        assert not os.path.exists(os.path.join(store, 'dd', 'ddNarrowAAAAAAAAAAAA.w1024.jpg'))
+        out = capsys.readouterr().out
+        assert 'Wrote %s' % os.path.join(store, 'aa', 'aaMissingCopyAAAAAAA.w1024.jpg') in out
+        assert 'FAILED %s' % os.path.join(store, 'ee', 'eeNotAJpegAAAAAAAAAA.jpg') in out
+
+    def test_a_second_run_changes_nothing(self, tmp_path):
+        store = self.seed(tmp_path)
+        downscale_panos.downscale_store(store, max_width=CAP)
+        before = {p: os.path.getmtime(os.path.join(store, p)) for p in
+                  ('aa/aaMissingCopyAAAAAAA.w1024.jpg', 'cc/ccStaleCopyAAAAAAAAA.w1024.jpg')}
+
+        summary = downscale_panos.downscale_store(store, max_width=CAP)
+
+        assert (summary.written, summary.current) == (0, 3)
+        assert {p: os.path.getmtime(os.path.join(store, p)) for p in before} == before
+
+    def test_a_dry_run_counts_without_decoding_or_writing(self, tmp_path, monkeypatch, capsys):
+        store = self.seed(tmp_path)
+        monkeypatch.setattr(Image, 'open', lambda *a, **k: pytest.fail('a dry run must not decode'))
+
+        summary = downscale_panos.downscale_store(store, dry_run=True, max_width=CAP)
+
+        assert (summary.written, summary.failed) == (2, 1)
+        assert not os.path.exists(os.path.join(store, 'aa', 'aaMissingCopyAAAAAAA.w1024.jpg'))
+        assert 'Would write' in capsys.readouterr().out
+
+    def test_a_write_that_fails_is_counted_and_the_sweep_goes_on(self, tmp_path, monkeypatch, capsys):
+        store = self.seed(tmp_path)
+
+        def refuse(pano_path, max_width=None, quality=None):
+            raise OSError(28, 'No space left on device')
+
+        monkeypatch.setattr(downscale_panos, 'write_downscaled_sidecar_from_file', refuse)
+        summary = downscale_panos.downscale_store(store, max_width=CAP)
+
+        assert (summary.written, summary.failed) == (0, 3)
+        assert 'No space left on device' in capsys.readouterr().out
+
+    def test_the_runtime_budget_leaves_the_rest_unreached(self, tmp_path, monkeypatch):
+        store = self.seed(tmp_path)
+        # Start, then one reading per pano: two panos inside the minute, everything after it past.
+        readings = [0.0, 0.0, 0.0]
+        monkeypatch.setattr(downscale_panos.time, 'monotonic', lambda: readings.pop(0) if readings else 61.0)
+
+        summary = downscale_panos.downscale_store(store, max_width=CAP, max_runtime_minutes=1)
+
+        # Two panos were examined before the clock passed the minute; the other three wait for the next run.
+        assert summary.scanned + summary.unreached == 5
+        assert summary.unreached == 3
+
+    def test_main_reports_the_summary_and_exits_nonzero_on_a_failure(self, tmp_path, monkeypatch, capsys):
+        store = self.seed(tmp_path)
+        monkeypatch.setattr(Image, 'MAX_IMAGE_PIXELS', 89478485)
+
+        assert downscale_panos.main([store, '--max-width', str(CAP)]) == 1
+
+        out = capsys.readouterr().out
+        assert 'Examined 5 panorama(s): 2 written, 1 under the cap, 1 already had a copy, 1 failed, 0 unreached.' in out
+        # The process-level policy CropRunner.main sets too: this script opens 134 MP files on purpose.
+        assert Image.MAX_IMAGE_PIXELS is None
+
+    def test_main_exits_zero_on_a_clean_store(self, tmp_path, monkeypatch, capsys):
+        two_tone_jpeg(str(tmp_path / 'aa' / 'aaMissingCopyAAAAAAA.jpg'), 2048, 1024)
+        monkeypatch.setattr(Image, 'MAX_IMAGE_PIXELS', 89478485)
+
+        assert downscale_panos.main([str(tmp_path), '--max-width', str(CAP), '--dry-run']) == 0
+
+        assert '1 would be written' in capsys.readouterr().out
+        assert os.listdir(tmp_path / 'aa') == ['aaMissingCopyAAAAAAA.jpg']


### PR DESCRIPTION
Fixes #115.

## Why this moved here

The Project Sidewalk web app renders a stored panorama as a single WebGL texture, and 8192 px is a common `MAX_TEXTURE_SIZE`, so a pano wider than that needs a copy at the cap to be viewable at all. Until now the app cut that copy itself, nightly, from the stored JPEG — and it OOM-killed its own JVMs doing it: 45 `OutOfMemoryError` exits across 21 of 61 prod stages in four nights (ProjectSidewalk/SidewalkWebpage#5239).

That was never going to work on the JVM. ImageIO has no DCT-domain scaling, and it re-walks the compressed stream from the start for every strip, so the app paid ~10 s and ~390 MiB of heap per pano inside a 1.5 GB heap it also serves requests from.

Here, the raster is **already in memory** when the pano is stitched, and Pillow's `Image.draft()` asks libjpeg to decode in the DCT domain at the largest power-of-two reduction that still meets the target — measured on a real 16384×8192 pano at **0.8 s and ~150 MB**, against 2.3 s and ~900 MB for a full decode. So the derivative belongs on this side of the line.

## What this adds

**`downloaders/common.py`** — the shared contract:

- `DOWNSCALED_MAX_WIDTH = 8192`, `DOWNSCALED_JPEG_QUALITY = 85`
- `downscaled_sidecar_path()` / `is_downscaled_sidecar()` — the sidecar is `<pano stem>.w<width>.jpg`, beside the native file. The width is in the name so a change of cap is a new sidecar rather than an ambiguous overwrite, and so the two can coexist during a migration.
- `downscaled_size()` — aspect kept, never upscaled, and **exactly `max_width`** for anything over the cap. That exactness is the contract: the app looks for the filename its own configured cap produces and then verifies the header width, so a copy that is merely *under* the cap would be passed over.
- `write_downscaled_sidecar()` (from an in-memory pano) and `write_downscaled_sidecar_from_file()` (from disk, for the backfill and the Mapillary path). Both reduce with `Image.BOX` — area averaging, which is the right filter for a large reduction and is exactly the 2×2 block mean in the 2:1 GSV case — and both write through `atomic_output_path`, so a half-written sidecar is never visible under its final name.

**Both downloaders** write the sidecar at stitch time for any pano over the cap. **Never fatal**: the native file is already the resume marker, so a sidecar that fails to write is retried by the backfill rather than losing the pano.

**`downscale_panos.py`** — a one-off backfill for a store that predates all this. Idempotent, `--max-runtime` bounded, and it judges each pano from two JPEG headers rather than decoding, so a store that is already complete costs a walk and nothing else.

**Sidecars are excluded by name from every walk** — `refetch_panos.walk_store` and the backfill's own. This is the one thing that can bite a future change: any code that lists the store's `*.jpg` and treats the stem as a pano id has to ask `is_downscaled_sidecar()` first, or it will invent pano ids like `<real id>.w8192`.

355 lines of new tests in `tests/test_downscaled_sidecar.py`.

## Ordering with the app side

Safe in either order, and neither side blocks the other. ProjectSidewalk/SidewalkWebpage#5247 is the app half: it deletes all the JVM downscaling and serves this sidecar from `/backupImage` when it is present, falling back to the native file when it is not — which is exactly what a stage sees today. Merging this first just means the app starts finding sidecars sooner.

**One coupling worth naming:** `DOWNSCALED_MAX_WIDTH` here and `pano.downscaled.max-width` in the app are the same number maintained in two repos, and nothing cross-checks them. Change one alone and the app looks for a filename that will never exist. The app side of #5247 now counts sidecar coverage on every nightly run and logs when copies are missing, so a mismatch surfaces within a day instead of silently — but the constants still have to be changed together.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — implementation by Fable 5.1 (`claude-fable-5-1`); PR description by Opus 5 (1M context), `claude-opus-5[1m]`
