### PR TITLE
pano_id_log.csv gains a fetch date (#114)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ Everything lives under the storage root, with two-char pano-id prefix sharding:
 | `<pano_id[:2]>/<pano_id>.jpg` | Stitched panorama |
 | `<pano_id[:2]>/<pano_id>.depth.npz` | Depth artifact (see below) |
 | `<pano_id[:2]>/<pano_id>.w8192.jpg` | Display copy of a pano wider than 8192 px (#115). **Not written automatically since 2026-09-09** — only by `downscale_panos.py`, plus `refetch_panos` refreshing one that already exists. Copies written before the switch are still on the store, so: **never list the store's `*.jpg` by hand — call `downloaders.common.walk_store_panos()`**, the one definition of "this file is a panorama"; a walker that forgets `is_downscaled_sidecar()` does not fail, it invents pano ids like `<real id>.w8192` |
-| `pano_id_log.csv` | Per-pano image ledger: `pano_id,downloaded` |
+| `pano_id_log.csv` | Per-pano image ledger: `pano_id,downloaded,fetched_at`; two-field rows predate 2026-09-10 (#114) and are never backfilled. `progress_check` accepts **both** widths - a bare `len(row) != 2` silently parses a timestamped ledger as EMPTY |
 | `depth_log.csv` | Per-pano depth ledger: `pano_id,saved\|unavailable` |
 | `log.csv` | One 18-column row per run |
 | `scrape.log` | Rotating run log (10 MB × 3) |

--- a/DownloadRunner.py
+++ b/DownloadRunner.py
@@ -93,11 +93,32 @@ def progress_check(csv_pano_log_path):
     the old rewrite path) is skipped, so a damaged ledger degrades to re-attempting a few panos instead of a
     ParserError that crashes every future run (#55). Reads with csv, not pandas, so the id type can never
     depend on what the ids happen to look like (#46).
+
+    TWO widths are legal, and this is the one place that knows it. Rows were `pano_id,downloaded` until
+    2026-09-10 and are `pano_id,downloaded,fetched_at` after it (#114), so every long-lived store holds
+    both: the header and the first million rows are two fields, everything appended since is three. Nothing
+    rewrites the old rows - see docs/ops.md - so tolerating the mixture here is not a migration step, it is
+    the permanent state.
+
+    Written as a membership test rather than `len(row) >= 2` deliberately. The looser form would accept a
+    four-field row, and a row with a surplus field is the signature of a torn append or a stray comma, which
+    is exactly the damage the tolerance above exists to survive rather than to trust. Widening this to a new
+    width is a decision, not a default.
+
+    The `!= 2` this replaced was load-bearing in the dangerous direction: it silently `continue`d on every
+    three-field row, so a timestamped ledger parsed as EMPTY. Nothing raises - the whole corpus reads as
+    unattempted, permanent `downloaded=0` verdicts stop being terminal and are re-requested against Google
+    every night, duplicate rows accumulate, and the prior-failure counters that seed log.csv's column 9 all
+    read zero. That is the shape of a rollback to a pre-#114 build, and it is why the writer and this reader
+    ship in the same commit.
+
+    The depth and refetch ledgers keep their own `!= 2`: neither gained a column, and a shared helper here
+    would let a future widening of one silently widen all three.
     """
     ledgered_ids, total_processed, total_success = set(), 0, 0
     with open(csv_pano_log_path, newline='') as f:
         for row in csv.reader(f):
-            if len(row) != 2 or row[0] == 'pano_id' or row[1] not in ('0', '1'):
+            if len(row) not in (2, 3) or row[0] == 'pano_id' or row[1] not in ('0', '1'):
                 continue
             ledgered_ids.add(row[0])
             total_processed += 1
@@ -398,7 +419,12 @@ def download_panorama_images(storage_path, pano_infos, run_start_monotonic=None,
         # trailing '\r' on the downloaded column.
         ledger = csv.writer(ledger_file, lineterminator='\n')
         if not ledger_existed:
-            ledger.writerow(['pano_id', 'downloaded'])
+            # Only a ledger this run CREATES gets the three-column header. An existing store keeps its
+            # two-column one above three-field rows, which looks wrong to a person running `head -1` and is
+            # correct anyway: rewriting a production ledger in place is the O(n^2) truncate-on-crash path
+            # the comment above warns about, over a file that is the only record of what has been scraped.
+            # progress_check reads by position and skips the header by value, so a stale one is inert.
+            ledger.writerow(['pano_id', 'downloaded', 'fetched_at'])
             ledger_file.flush()
             # Group-writable like depth_log.csv: other lab users' runs append to the same store.
             try:
@@ -491,7 +517,12 @@ def download_panorama_images(storage_path, pano_infos, run_start_monotonic=None,
             total_completed = success_count + fallback_success_count + fail_count + skipped_count
 
             if downloaded is not None:
-                ledger.writerow([pano_id, downloaded])
+                # fetched_at goes LAST so `cut -d, -f1` and `-f2` keep meaning what every ops procedure and
+                # every `grep ',0$'` in docs/ops.md assumes. It reuses log_timestamp for the same reason
+                # log.csv's column 1 does (#101): a stamp that does not say which clock it is on is
+                # silently 7-8 hours out the moment a host is not on UTC, and there is no second timestamp
+                # convention on this store to get that wrong differently.
+                ledger.writerow([pano_id, downloaded, log_timestamp()])
                 ledger_file.flush()
                 df_id_set.add(pano_id)
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ One directory per city, sharded by the first two characters of the pano id:
 | `<pano_id[:2]>/<pano_id>.jpg` | Stitched panorama |
 | `<pano_id[:2]>/<pano_id>.depth.npz` | Depth artifact |
 | `<pano_id[:2]>/<pano_id>.w8192.jpg` | Display copy of a panorama wider than 8192 px (no longer written by the downloaders) |
-| `pano_id_log.csv` | Image ledger — a row means the outcome is permanent |
+| `pano_id_log.csv` | Image ledger — a row means the outcome is permanent, and carries when it was reached |
 | `depth_log.csv` | Depth ledger — likewise |
 | `log.csv` | One 18-column row per run |
 | `scrape.log` | Rotating run log |

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -12,7 +12,7 @@ Everything lives under the storage root, sharded by the first two characters of 
 | `<pano_id[:2]>/<pano_id>.jpg` | Stitched panorama |
 | `<pano_id[:2]>/<pano_id>.depth.npz` | [Depth artifact](depth.md#the-artifact) |
 | `<pano_id[:2]>/<pano_id>.w8192.jpg` | [Display copy](#display-copies-of-wide-panoramas) of a panorama wider than 8192 px. **No longer written automatically** — see that section |
-| `pano_id_log.csv` | Per-pano image ledger: `pano_id,downloaded` |
+| `pano_id_log.csv` | Per-pano image ledger: `pano_id,downloaded,fetched_at` (rows written before 2026-09-10 have no `fetched_at`) |
 | `depth_log.csv` | Per-pano depth ledger: `pano_id,saved\|unavailable` |
 | `log.csv` | One 18-column row per run |
 | `scrape.log` | Rotating run log (10 MB × 3) |
@@ -184,7 +184,7 @@ compares them across runs as `pose_drift`. It catches the re-poses, not the pure
 Both phases resume from an append-only ledger, and both draw the same line: **a row means the outcome is
 permanent.** Transient failures leave no row and retry automatically on the next run.
 
-**`pano_id_log.csv` gates the image phase** (`pano_id,downloaded`):
+**`pano_id_log.csv` gates the image phase** (`pano_id,downloaded,fetched_at`):
 
 * `1` — image on disk, or a prior success.
 * `0` — the source has nothing for this pano. A permanent verdict, one per source:
@@ -211,6 +211,36 @@ permanent.** Transient failures leave no row and retry automatically on the next
 
 Deleting `0` rows, or the whole file, is the manual force-retry lever; existing `.jpg`s are simply
 re-registered as skipped rather than re-downloaded.
+
+### `fetched_at`, and the two row widths
+
+The third field is when the verdict was reached: local time with an explicit UTC offset, the same
+`log_timestamp()` rendering as [`log.csv`'s column 1](#which-clock-each-field-is-on), so it says which clock
+it is on. It exists because [the store is an archive](#the-store-is-an-archive-not-a-cache) and file mtime
+was the only record of when a panorama was fetched — a record `refetch_panos`'s `already_clean` gate already
+leans on, and one that any `cp` or `rsync` without `-t` destroys.
+
+**Two widths are legal and a long-lived store holds both.** Rows written before 2026-09-10 are
+`pano_id,downloaded`; rows after it are `pano_id,downloaded,fetched_at`. Three specifics follow:
+
+* **Old rows are never backfilled.** Three fields means we know when; two means it predates the change and
+  mtime is the only evidence there will ever be. Inventing a timestamp from an mtime we already distrust
+  would be worse than the blank.
+* **A store created before the change keeps its two-column header** above three-field rows, so `head -1`
+  under-reports. Deliberate: rewriting a production ledger in place is the O(n²) truncate-on-crash path
+  [#55](https://github.com/ProjectSidewalk/sidewalk-panorama-tools/pull/55) removed, over the only record of
+  what has been scraped. `progress_check` reads by position and skips the header by value, so a stale header
+  costs nothing. A `csv.DictReader` on such a file *will* put the stamp under the `None` key — read it
+  positionally.
+* **The stamp is the last field on purpose**, so `cut -d, -f1`, `cut -d, -f2` and `grep ',0$'`-style
+  recovery greps keep meaning what they meant.
+
+**A rollback is the one thing to be careful about.** A build older than 2026-09-10 reads rows with a hard
+`len(row) != 2` and silently skips every three-field one — so a fully-timestamped ledger parses as *empty*,
+with nothing raised: permanent `0` verdicts stop being terminal and go back to Google nightly, duplicate rows
+accumulate, and `log.csv`'s column 9 loses its prior-failure seed. Reader and writer ship in one commit, so
+this cannot happen from a partial deploy; it can only happen by deliberately deploying an older build over a
+store that has already been written. Roll forward rather than repairing.
 
 **`depth_log.csv` gates the depth phase** with the same semantics — see
 [Depth maps → The ledger](depth.md#the-ledger). The artifacts on disk are the ground truth; deleting the
@@ -482,7 +512,7 @@ is damage.
 
 They are **not** necessarily the last rows *in the file*. Only the tripped source stops; a city carrying both
 GSV and Mapillary keeps downloading and ledgering GSV afterwards, so the tail can be thousands of GSV rows.
-`pano_id_log.csv` is `pano_id,downloaded` with no source column, so match on the id shape — Mapillary ids are
+`pano_id_log.csv` has no source column, so match on the id shape — Mapillary ids are
 all-numeric, GSV's are 22-character base64, Panoramax's are UUIDs. Delete those two rows, fix the
 credentials, and the next run picks up everything the breaker skipped, because none of it was ledgered.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -37,6 +37,7 @@ Two settings there are load-bearing, and losing either shows up as a *lower numb
 | Area | Files |
 |---|---|
 | Downloader: run flow, budgets, ledgers, crash/`SIGTERM` behaviour, the positional `log.csv` contract | `test_download_runner.py` |
+| The image ledger's [two legal row widths](ops.md#fetched_at-and-the-two-row-widths): a mixed-width file reading as the union of its ids, a timestamped `0` row staying terminal, an existing two-column header left alone, a four-field row still counting as damage, and the stamp carrying a UTC offset | `test_download_runner.py` (`TestTheFetchTimestamp`) |
 | Depth phase: ledger semantics, error taxonomy, artifact format, budget flags | `test_depth_phase.py`, `test_depth_helpers.py` |
 | Depth pacing (adaptive floor/backoff/jitter) and the cross-run block latch | `test_depth_pacing.py` |
 | GSV stitching and the tile endpoint's behaviour, pinned against captured bytes | `test_gsv_stitcher.py`, `test_gsv_tile_contract.py`, `test_image_downloaders.py` |

--- a/tests/test_download_runner.py
+++ b/tests/test_download_runner.py
@@ -61,6 +61,23 @@ def last_log_fields(storage):
         return f.read().strip().splitlines()[-1].split(',')
 
 
+def ledger_verdict_rows(storage, sort=True):
+    """The image ledger's `pano_id,downloaded` pairs, with the fetch timestamp dropped.
+
+    Rows gained a third field, `fetched_at`, in #114. Every assertion in this file is about WHICH panos got
+    WHICH verdict and none is about when - and a wall-clock stamp is not something an equality assertion
+    can name anyway - so the column is dropped here rather than in the twenty-odd literal expectations that
+    would otherwise each have to grow a wildcard.
+
+    Deliberately blind to the timestamp rather than tolerant of it: the stamp is pinned on its own in
+    TestTheFetchTimestamp, and a helper that quietly accepted a row with or without one would let the
+    writer stop emitting it with nothing failing.
+    """
+    lines = (storage / 'pano_id_log.csv').read_text().strip().splitlines()[1:]
+    pairs = [','.join(line.split(',')[:2]) for line in lines]
+    return sorted(pairs) if sort else pairs
+
+
 def test_scrape_log_lands_in_storage_not_cwd(tmp_path):
     """A relative scrape.log resolves against whatever CWD cron happened to hand the process. It must live on
     the pano store next to log.csv, where a failed run's evidence survives and the operator looks (#49)."""
@@ -478,7 +495,7 @@ def test_max_runtime_flag_reaches_the_image_download_loop(monkeypatch, tmp_path,
     assert calls == []
     assert 'IMAGEDOWNLOAD: Max runtime' in capsys.readouterr().out
     with open(storage / 'pano_id_log.csv') as f:
-        assert f.read().strip() == 'pano_id,downloaded', "no pano may be attempted or logged"
+        assert f.read().strip() == 'pano_id,downloaded,fetched_at', "no pano may be attempted or logged"
 
 
 def test_without_max_runtime_every_supported_pano_is_downloaded(monkeypatch, tmp_path):
@@ -488,8 +505,8 @@ def test_without_max_runtime_every_supported_pano_is_downloaded(monkeypatch, tmp
     with open(storage / 'pano_id_log.csv') as f:
         lines = f.read().strip().splitlines()
     # The ledger is written in attempt order, which the loop shuffles; the header's position is not.
-    assert lines[0] == 'pano_id,downloaded'
-    assert sorted(lines[1:]) == sorted('%s,1' % p for p in GSV_PANO_IDS)
+    assert lines[0] == 'pano_id,downloaded,fetched_at'
+    assert ledger_verdict_rows(storage) == sorted('%s,1' % p for p in GSV_PANO_IDS)
 
 
 def test_broken_scrape_log_falls_back_to_stderr_and_the_run_survives(tmp_path):
@@ -718,14 +735,13 @@ class TestRetrySemantics:
 
         assert result == (0, 0, 1, 0, 1), "the failure still counts in THIS run's totals"
         with open(storage / 'pano_id_log.csv') as f:
-            assert f.read().strip() == 'pano_id,downloaded', "a transient failure must leave no ledger row"
+            assert f.read().strip() == 'pano_id,downloaded,fetched_at', "a transient failure must leave no ledger row"
 
         monkeypatch.setattr(DownloadRunner, 'download_pano', recording_download_pano(attempts))
         DownloadRunner.download_panorama_images(str(storage), gsv_pano_infos()[:1])
 
         assert attempts == [GSV_PANO_IDS[0], GSV_PANO_IDS[0]], "the next run must re-attempt it"
-        with open(storage / 'pano_id_log.csv') as f:
-            assert f.read().strip().splitlines()[1:] == ['%s,1' % GSV_PANO_IDS[0]]
+        assert ledger_verdict_rows(storage, sort=False) == ['%s,1' % GSV_PANO_IDS[0]]
 
     def test_permanent_failure_writes_zero_row_and_is_never_reattempted(self, monkeypatch, tmp_path):
         """DownloadResult.failure is the downloader's verdict on the PANO itself (no imagery at either zoom,
@@ -742,8 +758,7 @@ class TestRetrySemantics:
         monkeypatch.setattr(DownloadRunner, 'download_pano', no_imagery)
         DownloadRunner.download_panorama_images(str(storage), gsv_pano_infos()[:1])
 
-        with open(storage / 'pano_id_log.csv') as f:
-            assert f.read().strip().splitlines()[1:] == ['%s,0' % GSV_PANO_IDS[0]]
+        assert ledger_verdict_rows(storage, sort=False) == ['%s,0' % GSV_PANO_IDS[0]]
 
         monkeypatch.setattr(DownloadRunner, 'download_pano', recording_download_pano(attempts))
         DownloadRunner.download_panorama_images(str(storage), gsv_pano_infos()[:1])
@@ -847,8 +862,7 @@ class TestFallbackResolutionReachesTheLog:
         monkeypatch.setattr(DownloadRunner, 'download_pano', self.fallback_download_pano(attempts))
         DownloadRunner.download_panorama_images(str(storage), gsv_pano_infos()[:1])
 
-        with open(storage / 'pano_id_log.csv') as f:
-            assert f.read().strip().splitlines()[1:] == ['%s,1' % GSV_PANO_IDS[0]]
+        assert ledger_verdict_rows(storage, sort=False) == ['%s,1' % GSV_PANO_IDS[0]]
 
         monkeypatch.setattr(DownloadRunner, 'download_pano', recording_download_pano(attempts))
         DownloadRunner.download_panorama_images(str(storage), gsv_pano_infos()[:1])
@@ -1083,8 +1097,12 @@ class TestLedgerHygiene:
         ParserError (#55)."""
         storage = tmp_path / 'storage'
         storage.mkdir()
+        # `a,b,c` used to be the wrong-width row here. Three fields became LEGAL in #114, so it now tests
+        # the value guard instead of the width guard - it is still rejected, because 'b' is not a verdict,
+        # but the test would have silently stopped covering what its name claims. `a,b,c,d` restores the
+        # width case, and both are kept because the reader has both guards.
         (storage / 'pano_id_log.csv').write_text(
-            'pano_id,downloaded\n%s,1\ntrunc\na,b,c\n' % GSV_PANO_IDS[0])
+            'pano_id,downloaded\n%s,1\ntrunc\na,b,c\na,b,c,d\n' % GSV_PANO_IDS[0])
         calls = []
         monkeypatch.setattr(DownloadRunner, 'download_pano', recording_download_pano(calls))
 
@@ -1129,7 +1147,118 @@ class TestLedgerHygiene:
 
         raw = (storage / 'pano_id_log.csv').read_bytes()
         assert b'\r' not in raw
-        assert raw.startswith(b'pano_id,downloaded\n')
+        assert raw.startswith(b'pano_id,downloaded,fetched_at\n')
+
+
+class TestTheFetchTimestamp:
+    """`pano_id_log.csv` gained a third field, `fetched_at`, in #114.
+
+    The store is an archive (docs/ops.md) and mtime was the only record of when a panorama was fetched -
+    which `refetch_panos`'s `already_clean` gate already leans on, and which any copy without `rsync -t`
+    destroys. This is that record, written where it survives a copy.
+
+    The whole change is two lines in the writer and one token in the reader, and the reader's token is the
+    dangerous one: `len(row) != 2` silently skips a three-field row, so a timestamped ledger would parse as
+    EMPTY with nothing raising. `test_a_mixed_width_ledger_reads_as_the_union` is the test that catches a
+    revert of it.
+    """
+
+    def ledger_lines(self, storage):
+        return (storage / 'pano_id_log.csv').read_text().strip().splitlines()
+
+    def test_a_row_carries_a_timestamp_that_says_which_clock_it_is_on(self, monkeypatch, tmp_path):
+        """log_timestamp, not a bare datetime.now(): a stamp with no offset is silently 7-8 hours out the
+        moment a scraper host is not on UTC, which is the #101 defect in log.csv's column 1. Asserting
+        tzinfo rather than a shape is what makes a naive stamp impossible to ship."""
+        storage, _ = call_main(monkeypatch, tmp_path, GSV_CSV_ROWS)
+
+        rows = self.ledger_lines(storage)[1:]
+        assert rows, 'the run ledgered nothing'
+        for row in rows:
+            fields = row.split(',')
+            assert len(fields) == 3, row
+            assert datetime.fromisoformat(fields[2]).tzinfo is not None, row
+
+    def test_the_stamp_is_last_so_ops_greps_keep_working(self, monkeypatch, tmp_path):
+        """Every recovery procedure in docs/ops.md reads the ledger by column position - `cut -d, -f1` for
+        the id, `,0$` for a permanent failure. Inserting the stamp anywhere but last would move the column
+        those read, silently."""
+        storage, _ = call_main(monkeypatch, tmp_path, GSV_CSV_ROWS)
+
+        for row in self.ledger_lines(storage)[1:]:
+            fields = row.split(',')
+            assert fields[0] in GSV_PANO_IDS
+            assert fields[1] in ('0', '1')
+
+    def test_a_mixed_width_ledger_reads_as_the_union(self):
+        """THE discrimination test for the reader change, and the ordinary state of every existing store:
+        a two-column header, a million two-field rows written before #114, three-field rows after it.
+
+        Against the old `len(row) != 2` the three-field rows vanish, so this returns only the old ids and
+        the counters under-report. Nothing raises - which is the whole problem, because in production that
+        reads as 'the corpus was never scraped'.
+        """
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, 'pano_id_log.csv')
+            with open(path, 'w', newline='') as f:
+                f.write('pano_id,downloaded\n'
+                        'old-success,1\n'
+                        'old-failure,0\n'
+                        'new-success,1,2026-09-10 11:04:05.123456-07:00\n'
+                        'new-failure,0,2026-09-10 11:04:06.123456-07:00\n')
+
+            ledgered, total, success, failure = DownloadRunner.progress_check(path)
+
+        assert ledgered == {'old-success', 'old-failure', 'new-success', 'new-failure'}
+        assert (total, success, failure) == (4, 2, 2)
+
+    def test_a_timestamped_permanent_failure_is_still_terminal(self, monkeypatch, tmp_path):
+        """The back-compat constraint that matters most: a `0` row means the source has nothing for this
+        pano and it is never re-attempted. If a three-field row were invisible to the reader, every
+        permanent failure would go back to Google every night - real request load, on exactly the panos
+        that fail."""
+        storage = tmp_path / 'storage'
+        storage.mkdir()
+        (storage / 'pano_id_log.csv').write_text(
+            'pano_id,downloaded,fetched_at\n%s,0,2026-09-10 11:04:05.123456-07:00\n' % GSV_PANO_IDS[0])
+        attempts = []
+        monkeypatch.setattr(DownloadRunner, 'download_pano', recording_download_pano(attempts))
+
+        DownloadRunner.download_panorama_images(str(storage), gsv_pano_infos()[:1])
+
+        assert attempts == [], 'a ledgered 0-row is terminal whether or not it carries a timestamp'
+
+    def test_an_existing_two_column_header_is_left_alone(self, monkeypatch, tmp_path):
+        """A store created before #114 keeps its two-column header above three-field rows. Rewriting it
+        would mean rewriting a production ledger in place - the O(n^2) truncate-on-crash path #55 removed -
+        over the only record of what has been scraped. The reader skips the header by value, so a stale one
+        costs nothing but a surprising `head -1`."""
+        storage = tmp_path / 'storage'
+        storage.mkdir()
+        (storage / 'pano_id_log.csv').write_text('pano_id,downloaded\nalready-done,1\n')
+        monkeypatch.setattr(DownloadRunner, 'download_pano', recording_download_pano([]))
+
+        DownloadRunner.download_panorama_images(str(storage), gsv_pano_infos()[:1])
+
+        lines = self.ledger_lines(storage)
+        assert lines[0] == 'pano_id,downloaded', 'the old header must not be rewritten'
+        assert len(lines[-1].split(',')) == 3, 'but new rows still carry the stamp'
+
+    def test_a_four_field_row_is_still_damage(self):
+        """Two widths are legal; a third is not. Written as a membership test rather than `>= 2` so a torn
+        append with a surplus field stays damage instead of being trusted."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, 'pano_id_log.csv')
+            with open(path, 'w', newline='') as f:
+                f.write('pano_id,downloaded\ngood,1,2026-09-10 11:04:05.123456-07:00\ntorn,1,stamp,extra\n')
+
+            ledgered, total, _, _ = DownloadRunner.progress_check(path)
+
+        assert ledgered == {'good'} and total == 1
 
 
 def test_pano_list_fetch_session_configuration(monkeypatch):
@@ -1526,7 +1655,7 @@ class TestAMapillaryVerdictReachesTheLedgerThroughTheRealDispatcher:
 
     @staticmethod
     def _ledger_rows(storage):
-        return sorted((storage / 'pano_id_log.csv').read_text().strip().splitlines()[1:])
+        return ledger_verdict_rows(storage)
 
     def test_only_a_verdict_on_the_pano_writes_a_row(self, monkeypatch, tmp_path):
         storage = tmp_path / 'storage'
@@ -1662,7 +1791,7 @@ class TestAPanoramaxVerdictReachesTheLedgerThroughTheRealDispatcher:
 
     @staticmethod
     def _ledger_rows(storage):
-        return sorted((storage / 'pano_id_log.csv').read_text().strip().splitlines()[1:])
+        return ledger_verdict_rows(storage)
 
     def test_only_a_verdict_on_the_picture_writes_a_row(self, monkeypatch, tmp_path):
         storage = tmp_path / 'storage'
@@ -1772,7 +1901,7 @@ class TestASourceThatFailsPermanentlyInARowStopsBeingLedgered:
 
     @staticmethod
     def ledger_rows(storage):
-        return (storage / 'pano_id_log.csv').read_text().strip().splitlines()[1:]
+        return ledger_verdict_rows(storage, sort=False)
 
     @staticmethod
     def mapillary_panos(count):

--- a/tests/test_refetch_panos.py
+++ b/tests/test_refetch_panos.py
@@ -590,7 +590,11 @@ class TestRefetchStore:
         `downloaded=1` for a repaired panorama, which is correct - it IS downloaded."""
         store_with_pano(tmp_path)
         sentinels = {}
-        for name, body in (('pano_id_log.csv', 'pano_id,downloaded\n%s,1\n' % PANO),
+        # Three fields, because that is what a current ledger holds (#114). A two-field sentinel would
+        # still pass - this asserts the bytes are untouched - but it would stop representing the file the
+        # repair pass actually runs beside, which is the whole point of a sentinel.
+        for name, body in (('pano_id_log.csv',
+                            'pano_id,downloaded,fetched_at\n%s,1,2026-09-10 11:04:05.123456-07:00\n' % PANO),
                            ('depth_log.csv', 'pano_id,status\n%s,saved\n' % PANO),
                            ('log.csv', '2026-01-01,0,0,0,0,0\n')):
             (tmp_path / name).write_text(body)


### PR DESCRIPTION
**Stacked on #128** — base is `114-rerender-probe`, so review that one first. Only the last commit here is new; the shared `docs/ops.md` and `CLAUDE.md` edits belong to #128 and stacking avoids a conflict between them.

Gives `pano_id_log.csv` a third field, `fetched_at`.

## Why

The store is an archive (#128 writes that rule down), and **file mtime was the only record of when a panorama was fetched** — a record `refetch_panos.py`'s `already_clean` gate already leans on, and one that any `cp` or `rsync` without `-t` silently destroys. This puts it somewhere that survives a copy.

It reuses `log_timestamp()` rather than minting a second convention: local time with an explicit UTC offset, fixed width. That helper exists because of #101 — a stamp that doesn't say which clock it's on is silently 7–8 hours out the moment a host isn't on UTC, and this store now has exactly one way to write a timestamp.

## The one line that matters

```diff
-if len(row) != 2 or row[0] == 'pano_id' or row[1] not in ('0', '1'):
+if len(row) not in (2, 3) or row[0] == 'pano_id' or row[1] not in ('0', '1'):
```

`progress_check` is the **only** reader of this file in the repo — verified by sweep: `log_analyzer`, `CropRunner`, `scrape_queue`, `migrate_depth_artifacts`, `flag_panos` and every `reports/scripts/*.py` are all negative. But that hard `!= 2` fails in the dangerous direction. Left alone, every three-field row is silently skipped and **a timestamped ledger parses as empty**, with nothing raised:

- permanent `downloaded=0` verdicts stop being terminal and go back to Google every night — real request load, on exactly the panos that fail;
- re-appends accumulate duplicate ids;
- the prior-failure counters that seed `log.csv` column 9 all read zero, and `log_analyzer` thresholds on that.

Reader and writer ship in the same commit, so a partial deploy can't produce this. A deliberate rollback onto an already-written store can, and `docs/ops.md` now says so and says to roll forward.

Written as a membership test rather than `>= 2` on purpose: a surplus field is the signature of a torn append, which is the damage the row-tolerance exists to *survive*, not to trust.

## Decisions worth disagreeing with

- **Old rows are not backfilled.** Three fields means we know when; two means it predates this and mtime is the only evidence there will ever be. Synthesising a timestamp from an mtime we already distrust is worse than the blank.
- **An existing store keeps its two-column header** above three-field rows, so `head -1` under-reports. Rewriting it means rewriting a production ledger in place — the O(n²) truncate-on-crash path #55 removed — over the only record of what's been scraped. The reader is positional and skips the header by value, so a stale one is inert. Documented rather than fixed. (A `csv.DictReader` on such a file puts the stamp under the `None` key; read positionally.)
- **The stamp goes last**, so `cut -d, -f1`, `-f2` and `grep ',0$'` recovery procedures in `docs/ops.md` keep meaning what they meant.
- **`depth_log.csv` and `refetch_log.csv` are untouched.** Neither gained a column, and they keep their own `!= 2` rather than sharing a helper — a shared one would let a future widening of one silently widen all three. Depth artifacts are reconstructible (the migrator proves it), so symmetry alone isn't a reason to touch a second production ledger.

## Tests

~25 assertion sites compared literal `'<id>,1'` rows. Rather than grow a wildcard in each, one `ledger_verdict_rows()` helper drops the timestamp and the three local copies delegate to it — that collapsed 15 of the 21 initial failures and keeps every breaker/dispatcher assertion reading as it did. The helper is deliberately *blind* to the stamp rather than tolerant of it, so the writer can't stop emitting one with nothing failing; `TestTheFetchTimestamp` pins the stamp itself.

**A test whose premise the change invalidated:** `test_damaged_ledger_rows_are_skipped_not_fatal` fed `a,b,c` as its wrong-width row. Three fields are now *legal*, so it silently became a test of the value guard (`'b'` is not a verdict) while its name still claimed width. `a,b,c,d` restores the width case; both are kept.

**Mutation evidence** — three checked, all caught:

| mutation | result |
|---|---|
| reader back to `len(row) != 2` | 9 failures, incl. `test_a_mixed_width_ledger_reads_as_the_union` |
| writer drops the timestamp | 2 failures |
| writer uses naive `str(datetime.now())` | 1 failure (the `tzinfo` assertion) |

The mixed-width test is the important one: a two-column header, two-field rows written before this, three-field rows after — the ordinary permanent state of every existing store, not a migration step.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]
